### PR TITLE
Split out actuator config/control from action manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ class Go2CEnv(ManagedEnvironment):
             },
         )
 
-        # Joint Actions
-        self.action_manager = PositionActionManager(
+        # Joint Actuators & Actions
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[".*"],
             default_pos={
@@ -88,10 +88,14 @@ class Go2CEnv(ManagedEnvironment):
                 ".*_thigh_joint": 0.8,
                 ".*_calf_joint": -1.5,
             },
+            kp=20,
+            kv=0.5,
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.25,
             use_default_offset=True,
-            pd_kp=20,
-            pd_kv=0.5,
+            actuator_manager=self.actuator_manager,
         )
 
         # Commanded direction

--- a/docs/api/managers/actuator.md
+++ b/docs/api/managers/actuator.md
@@ -1,0 +1,5 @@
+# Actuator
+
+```{eval-rst}
+.. autoclass:: genesis_forge.managers.actuator.ActuatorManager
+```

--- a/docs/api/managers/command/command.md
+++ b/docs/api/managers/command/command.md
@@ -1,4 +1,4 @@
-# Command
+# CommandManager
 
 ```{eval-rst}
 .. autoclass:: genesis_forge.managers.command.CommandManager

--- a/docs/api/managers/command/velocity.md
+++ b/docs/api/managers/command/velocity.md
@@ -1,4 +1,4 @@
-# Velocity
+# VelocityCommandManager
 
 ```{eval-rst}
 .. autoclass:: genesis_forge.managers.command.VelocityCommandManager

--- a/docs/api/managers/index.md
+++ b/docs/api/managers/index.md
@@ -4,6 +4,7 @@ These modular classes are used to handle dedicated parts of your environment.
 
 ```{toctree}
 :maxdepth: 2
+actuator
 action/index
 command/index
 contact

--- a/docs/api/managers/noisy_value.md
+++ b/docs/api/managers/noisy_value.md
@@ -1,0 +1,5 @@
+# Noisy Value
+
+```{eval-rst}
+.. autoclass:: genesis_forge.managers.actuator.NoisyValue
+```

--- a/docs/guide/managers/action.md
+++ b/docs/guide/managers/action.md
@@ -1,6 +1,7 @@
 # Action Manager
 
-The Action Manager is responsible for mapping actions from your RL policy to robot actuator inputs, or other behaviors. It handles scaling, offsets, joint limits, and PD controller configuration.
+The Action Manager is responsible for mapping actions from your RL policy to robot actuator inputs, or other behaviors. The action manager uses the actuator
+manager to send the action positions to the actuators.
 
 You can see a full example using the action manager in [examples/simple](https://github.com/jgillick/genesis-forge/tree/main/examples/simple).
 
@@ -15,11 +16,11 @@ position = offset + scaling * action
 By setting the offset to the default stable position (via `default_pos` and `use_default_offset` params), the policy will learn what is stable early, which can lead to faster convergence.
 
 ```python
-from genesis_forge.managers import PositionActionManager
+from genesis_forge.managers import PositionActionManager, ActuatorManager
 
 class MyEnv(ManagedEnvironment):
     def config(self):
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[".*"],      # Control all joints
             default_pos={            # Set a default stable position
@@ -27,10 +28,14 @@ class MyEnv(ManagedEnvironment):
                 ".*_thigh_joint": 0.8,
                 ".*_calf_joint": -1.5,
             },
+            kp=20, # PD controller positional gains
+            kv=0.5, # PD controller velocity gains
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.25,              # Scale actions by 0.25
             use_default_offset=True, # Add default positions as offset
-            pd_kp=20,                # Proportional gain
-            pd_kv=0.5,               # Derivative gain
+            actuator_manager=self.actuator_manager,
         )
 ```
 
@@ -60,14 +65,19 @@ Control how actions are offset:
 
 ```python
 # Option 1: Use default positions as offset
-self.action_manager = PositionActionManager(
+self.actuator_manager = ActuatorManager(
     self,
-    default_pos={            # Neutral stable position for all joints
+    default_pos={ # Set a default stable position
         ".*_hip_joint": 0.0,
         ".*_thigh_joint": 0.8,
         ".*_calf_joint": -1.5,
-    }
-    use_default_offset=True,  # action = default_pos + scale * raw_action
+    },
+    # ...
+)
+self.action_manager = PositionActionManager(
+    self,
+    use_default_offset=True,  # action = actuator_manager.default_pos + scale * raw_action
+    actuator_manager=self.actuator_manager,
 )
 
 # Option 2: Use custom offset
@@ -75,93 +85,8 @@ self.action_manager = PositionActionManager(
     self,
     offset=0.2, # Apply this offset to all joints
     use_default_offset=False,
+    # ...
 )
-```
-
-## Custom values per joint
-
-Any parameter typed with `DofValue` can either be a value for all joints, or be a dict of joint name/patterns to values.
-
-For example, if all your actuators are the same, you can set the PD controller values like this:
-
-```python
-self.action_manager = PositionActionManager(
-    self,
-    pd_kp=50,  # Proportional gain (stiffness)
-    pd_kv=1.0, # Derivative gain (damping)
-)
-```
-
-However, if different joints have different gains:
-
-```python
-self.action_manager = PositionActionManager(
-    self,
-    pd_kp={
-      ".*_hip_joint": 20,
-      ".*_thigh_joint": 50,
-      ".*_calf_joint": 42,
-    }
-    pd_kv={
-      ".*_hip_joint": 1.0,
-      ".*_thigh_joint": 0.5,
-      ".*_calf_joint": 0.5,
-    }
-)
-```
-
-## Sim2Real
-
-Add attributes like damping, stiffness and friction to the joints.
-
-```python
-self.action_manager = PositionActionManager(
-    self,
-    # ... other params...
-    damping={".*": 0.1},
-    stiffness={".*": 100},
-    frictionloss={".*": 0.01},
-)
-```
-
-Setting the noise value will scale all values with a bit of random noise:
-
-```python
-self.action_manager = PositionActionManager(
-    self,
-    # ... other params...
-    noise=0.02
-)
-```
-
-## Accessing Joint Information
-
-### Get Current Joint States
-
-```python
-# In your reward or observation functions
-positions = self.action_manager.get_dofs_position()
-velocities = self.action_manager.get_dofs_velocity()
-forces = self.action_manager.get_dofs_force()
-
-# Add noise for training robustness
-noisy_pos = self.action_manager.get_dofs_position(noise=0.01)
-```
-
-### Get Action Information
-
-```python
-# Get the last actions sent to the robot
-actions = self.action_manager.get_actions()
-
-# Get the default positions
-default_pos = self.action_manager.default_dofs_pos
-
-# Get the number of controlled DOFs
-num_actions = self.action_manager.num_actions
-
-# Get the action space
-action_space = self.action_manager.action_space
 ```
 
 ## PositionWithinLimitsActionManager
@@ -169,17 +94,45 @@ action_space = self.action_manager.action_space
 This action manager is similar to PositionActionManager, but sets the action space range to `-1.0 - 1.0` and converts the received action from that range to an absolute position within the limits of your actuator. This is useful if you need your policy to use the full range of your actuators, however, it might take longer to learn the default stable position.
 
 ```python
-from genesis_forge.managers import PositionWithinLimitsActionManager
+from genesis_forge.managers import PositionWithinLimitsActionManager, ActuatorManager
 
+self.actuator_manager = ActuatorManager(
+    # ...
+)
 self.action_manager = PositionWithinLimitsActionManager(
     self,
-    joint_names=[".*"],
-    position_limits={
-        ".*_hip_joint": (-0.3, 0.3),
-        ".*_thigh_joint": (0.5, 1.5),
-        ".*_calf_joint": (-2.0, -1.0),
-    },
-    pd_kp=30,
-    pd_kv=1.0,
+    actuator_manager=self.actuator_manager,
 )
+```
+
+## Sim2Real - Action latency
+
+In most robots, there is some latency between when the action is received, and when it is acted upon by the actuator. To roughly emulate this, you can set the `delay_step` parameter.
+
+```python
+self.action_manager = PositionActionManager(
+    self,
+    delay_step=1 # Delay sending actions to actuators by one step (dt)
+    scale=0.25,
+    use_default_offset=True,
+    actuator_manager=self.actuator_manager,
+)
+```
+
+This parameter lets use delay sending the actions to the actuators by a specific number of training steps.
+
+## Get Action Information
+
+```python
+# Get the last actions sent to the robot
+actions = self.action_manager.get_actions()
+
+# Get the last raw action values, before they were converted to joint positions
+actions = self.action_manager.raw_actions
+
+# Get the number of controlled DOFs
+num_actions = self.action_manager.num_actions
+
+# Get the action space
+action_space = self.action_manager.action_space
 ```

--- a/docs/guide/managers/actuator.md
+++ b/docs/guide/managers/actuator.md
@@ -1,0 +1,277 @@
+# Actuator Manager
+
+The Actuator Manager configures and manages the DOF actuators (joints) of your robot. It handles setting PD controller gains, default positions, force limits, and physical properties like damping and stiffness. The actuator manager is generally used in concert with the [Action Manager](action.md) to control the robot.
+
+You can see a full example using the actuator manager in [examples/simple](https://github.com/jgillick/genesis-forge/tree/main/examples/simple).
+
+## Basic Setup
+
+The simplest way to use the ActuatorManager is to configure it with basic PD controller gains:
+
+```python
+from genesis_forge import ManagedEnvironment
+from genesis_forge.managers import ActuatorManager, PositionActionManager
+
+class MyEnv(ManagedEnvironment):
+    def config(self):
+        # Configure actuators
+        self.actuator_manager = ActuatorManager(
+            self,
+            joint_names=[".*"],      # Control all joints
+            default_pos={            # Default position for all joints.
+                ".*_hip_joint": 0.0,
+                ".*_thigh_joint": 0.8,
+                ".*_calf_joint": -1.5,
+            },
+            kp=20,                   # Proportional gain (stiffness)
+            kv=0.5,                  # Derivative gain (damping)
+        )
+
+        # Use with action manager
+        self.action_manager = PositionActionManager(
+            self,
+            actuator_manager=self.actuator_manager,
+            # ... other settings ...
+        )
+```
+
+## Joint Selection
+
+You first need to tell the actuator manager which joints will be controlled, as actuators, by it.
+Set `joint_names` to either a single regex pattern, a list of joint names, or a list of regex patterns.
+
+```python
+# Control all joints
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=".*",
+)
+
+# Control specific joints by name pattern
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[
+        "FL_.*_joint",  # All front-left joints
+        "FR_.*_joint",  # All front-right joints
+        "RL_.*_joint",  # All rear-left joints
+        "RR_.*_joint",  # All rear-right joints
+    ],
+)
+
+# Control specific joints by exact name
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[
+        "FL_hip_joint",
+        "FL_thigh_joint",
+        "FL_calf_joint",
+    ],
+)
+```
+
+## Default Positions
+
+Set default positions for joints that will be applied during environment reset.
+These generally create a stable initial position for the robot. Similar to the `joint_names`
+parameter, these can be regular expressions or exact names.
+
+```python
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    default_pos={
+        ".*_hip_joint": 0.0,
+        ".*_thigh_joint": 0.8,
+        ".*_calf_joint": -1.5,
+    },
+    kp=20,
+    kv=0.5,
+)
+```
+
+You can also set different default positions per leg:
+
+```python
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    default_pos={
+        ".*_hip_joint": 0.0,
+        "FL_thigh_joint": 0.8,
+        "FR_thigh_joint": 0.8,
+        "RL_thigh_joint": 1.0,  # Rear legs slightly different
+        "RR_thigh_joint": 1.0,
+        ".*_calf_joint": -1.5,
+    },
+    kp=20,
+    kv=0.5,
+)
+```
+
+## PD Controller Gains
+
+Configure proportional (kp) and derivative (kv) gains for the PD controller:
+
+```python
+# Uniform gains for all joints
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    kp=20, # Positional gains
+    kv=0.5, # Velocity gains
+)
+
+# Per-joint gains
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    kp={
+        ".*_hip_joint": 30,
+        ".*_thigh_joint": 20,
+        ".*_calf_joint": 20,
+    },
+    kv={
+        ".*_hip_joint": 1.0,
+        ".*_thigh_joint": 0.5,
+        ".*_calf_joint": 0.5,
+    },
+)
+```
+
+## Force Limits
+
+Constrain the maximum force that actuators can apply:
+
+```python
+# Uniform force limit
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    max_force=8.0,  # +/- 8.0 N
+    kp=20,
+    kv=0.5,
+)
+
+# Per-joint force limits
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    max_force={
+        ".*_hip_joint": 10.0,
+        ".*_thigh_joint": 8.0,
+        ".*_calf_joint": 6.0,
+    },
+    kp=20,
+    kv=0.5,
+)
+
+# Asymmetric force limits (min, max)
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    max_force={
+        ".*_hip_joint": (-12.0, 10.0),   # Different limits for each direction
+        ".*_thigh_joint": (-8.0, 8.0),
+        ".*_calf_joint": (-6.0, 6.0),
+    },
+    kp=20,
+    kv=0.5,
+)
+```
+
+## Sim2Real - Physical Properties
+
+Set physical properties like damping, stiffness, friction loss, and armature, to match your real actuators.
+
+```python
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    kp=20,
+    kv=0.5,
+    damping=0.1,        # Joint damping
+    stiffness=100,      # Joint stiffness
+    frictionloss=0.01,  # Friction loss
+    armature=0.01,      # Rotor inertia
+)
+```
+
+These can also be set per-joint using dictionary patterns:
+
+```python
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    kp=20,
+    kv=0.5,
+    damping={
+        ".*_hip_joint": 0.2,
+        ".*_thigh_joint": 0.1,
+        ".*_calf_joint": 0.1,
+    },
+)
+```
+
+## Domain Randomization
+
+Add domain randomization to any actuator value using `NoisyValue`.
+
+```python
+from genesis_forge.managers import ActuatorManager, NoisyValue
+
+self.actuator_manager = ActuatorManager(
+    self,
+    joint_names=[".*"],
+    kp=NoisyValue(20, noise=0.02),   # 20 +/- 0.02
+    kv=NoisyValue(0.5, noise=0.01),  # 0.5 +/- 0.01
+    max_force=NoisyValue(8.0, noise=0.05),  # 8.0 +/- 0.05
+)
+```
+
+The noise value has a base number, and the noise to add to it. For example:
+
+```python
+NoisyValue(20, noise=0.5)
+```
+
+In this case, the base value is `20` and random noise will be added to it in the range of `-0.5` to `+0.5`.
+The noise is randomized across each join at environment reset.
+
+## Accessing Joint Information
+
+The ActuatorManager provides several methods to access joint states:
+
+### Get Joint Information
+
+```python
+# Get joint properties
+num_dofs = self.actuator_manager.num_dofs
+dof_names = self.actuator_manager.dofs_names
+dof_indices = self.actuator_manager.dofs_idx
+default_positions = self.actuator_manager.default_dofs_pos
+```
+
+### Get Current Joint States
+
+```python
+# In your observation or reward functions
+positions = self.actuator_manager.get_dofs_position()
+velocities = self.actuator_manager.get_dofs_velocity()
+forces = self.actuator_manager.get_dofs_force()
+
+# Add noise for training robustness
+noisy_pos = self.actuator_manager.get_dofs_position(noise=0.01)
+noisy_vel = self.actuator_manager.get_dofs_velocity(noise=0.02)
+```
+
+### Set Joint States
+
+```python
+# Set joint positions directly
+positions = torch.zeros((self.num_envs, self.actuator_manager.num_dofs))
+self.actuator_manager.set_dofs_position(positions)
+
+# Control joint positions (PD controller)
+target_positions = torch.zeros((self.num_envs, self.actuator_manager.num_dofs))
+self.actuator_manager.control_dofs_position(target_positions)
+```

--- a/docs/guide/managers/index.md
+++ b/docs/guide/managers/index.md
@@ -26,7 +26,8 @@ class MyEnv(ManagedEnvironment):
 
     def config(self):
         """Configure all managers here"""
-        self.action_manager = PositionActionManager(self, ...)
+        self.actuators = ActuatorManager(self, ...)
+        PositionActionManager(self, ...)
         RewardManager(self, ...)
         TerminationManager(self, ...)
         ObservationManager(self, ...)

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,9 @@
 
 This directory contains a series of examples demonstrating how to use Genesis Forge. Each example builds on the previous one, in this order:
 
-1. [Simple](./simple/)
+1. [Simple locomotion](./simple/)
 2. [Command Direction](./command_direction/)
-3. [Contacts - Foot air time](./contacts/)
-4. [Rough Terrain](./rough_terrain/)
-5. [Gait Trainer](./gait_trainer/)
+3. [Contact Sensors and foot air time](./contacts/)
+4. [Domain Randomization](./domain_randomization/)
+5. [Rough Terrain](./rough_terrain/)
+6. [Gait Trainer](./gait_trainer/)

--- a/examples/berkeley_humanoid/environment.py
+++ b/examples/berkeley_humanoid/environment.py
@@ -6,6 +6,7 @@ from genesis_forge.managers import (
     TerminationManager,
     EntityManager,
     ObservationManager,
+    ActuatorManager,
     PositionActionManager,
     VelocityCommandManager,
     ContactManager,
@@ -103,9 +104,11 @@ class BerkeleyHumanoidEnv(ManagedEnvironment):
 
         ##
         # Joint Actions & actuator configuration
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[".*"],
+            kp=15.0,
+            kv=1.0,
             default_pos={
                 "LL_HR": -0.071,
                 "LR_HR": 0.071,
@@ -120,10 +123,6 @@ class BerkeleyHumanoidEnv(ManagedEnvironment):
                 "LL_FAA": 0.126,
                 "LR_FAA": -0.126,
             },
-            scale=0.5,
-            use_default_offset=True,
-            pd_kp=15.0,
-            pd_kv=1.0,
             max_force={
                 ".*_HR": 20.0,
                 ".*_HAA": 20.0,
@@ -132,6 +131,12 @@ class BerkeleyHumanoidEnv(ManagedEnvironment):
                 ".*_FFE": 20.0,
                 ".*_FAA": 5.0,
             },
+        )
+        self.action_manager = PositionActionManager(
+            self,
+            scale=0.5,
+            use_default_offset=True,
+            actuator_manager=self.actuator_manager,
         )
 
         ##
@@ -272,4 +277,3 @@ class BerkeleyHumanoidEnv(ManagedEnvironment):
                 },
             },
         )
-

--- a/examples/command_direction/environment.py
+++ b/examples/command_direction/environment.py
@@ -2,6 +2,7 @@ import genesis as gs
 
 from genesis_forge import ManagedEnvironment
 from genesis_forge.managers import (
+    ActuatorManager,
     RewardManager,
     TerminationManager,
     EntityManager,
@@ -106,14 +107,9 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
 
         ##
         # Joint Actions
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
-            joint_names=[
-                "FL_.*_joint",
-                "FR_.*_joint",
-                "RL_.*_joint",
-                "RR_.*_joint",
-            ],
+            joint_names=[".*"],
             default_pos={
                 ".*_hip_joint": 0.0,
                 "FL_thigh_joint": 0.8,
@@ -122,10 +118,14 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 "RR_thigh_joint": 1.0,
                 ".*_calf_joint": -1.5,
             },
+            kp=20,
+            kv=0.5,
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.25,
             use_default_offset=True,
-            pd_kp=20,
-            pd_kv=0.5,
+            actuator_manager=self.actuator_manager,
         )
 
         ##
@@ -245,4 +245,3 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 },
             },
         )
-

--- a/examples/contacts/environment.py
+++ b/examples/contacts/environment.py
@@ -2,7 +2,6 @@
 Simplified Go2 Locomotion Environment using managers to handle everything.
 """
 
-import torch
 import genesis as gs
 
 from genesis_forge import ManagedEnvironment
@@ -11,6 +10,7 @@ from genesis_forge.managers import (
     TerminationManager,
     EntityManager,
     ObservationManager,
+    ActuatorManager,
     PositionActionManager,
     VelocityCommandManager,
     ContactManager,
@@ -110,7 +110,7 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
 
         ##
         # Joint Actions
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[
                 "FL_.*_joint",
@@ -126,10 +126,14 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 "RR_thigh_joint": 1.0,
                 ".*_calf_joint": -1.5,
             },
+            kp=20,
+            kv=0.5,
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.5,
             use_default_offset=True,
-            pd_kp=20,
-            pd_kv=0.5,
+            actuator_manager=self.actuator_manager,
         )
 
         ##

--- a/examples/domain_randomization/README.md
+++ b/examples/domain_randomization/README.md
@@ -1,0 +1,91 @@
+# Go2 - Domain Randomization
+
+A common way to ensure a smoother [Sim2Real](https://medium.com/@sim30217/sim2real-fa835321342a) transition is using "domain randomization" during training.
+This basically means adding noise to the environment, so that the robot adapts and learns a more general and robust policy.
+
+This builds on the [command_direction](../command_direction/) example, and introduces random noise in these places:
+
+- Actuator values (gains, default positions, damping, etc) - No actuator performs as perfect as the data sheet, so the policy learns to adapt.
+- Observations - No sensors return perfectly clean data.
+- Robot mass - Makes the robot heavier or lighter at each reset to change it's balance and loading.
+
+Here are the relevant snippets:
+
+```python
+    # Randomly add/subtract mass to the robot's body
+    self.robot_manager = EntityManager(
+        self,
+        entity_attr="robot",
+        on_reset={
+            "mass": {
+                "fn": reset.randomize_link_mass_shift,
+                "params": {
+                    "link_name": "base",
+                    "add_mass_range": [-100.0, 100.0],
+                },
+            },
+        },
+    )
+
+    # Actuator settings with random noise
+    self.actuator_manager = ActuatorManager(
+        self,
+        joint_names=[".*"],
+        default_pos={
+            # Randomize the default positions by +/- 0.1 radians
+            ".*_hip_joint": NoisyValue(0.0, 0.05),
+            "FL_thigh_joint": NoisyValue(0.8, 0.05),
+            "FR_thigh_joint": NoisyValue(0.8, 0.05),
+            "RL_thigh_joint": NoisyValue(1.0, 0.05),
+            "RR_thigh_joint": NoisyValue(1.0, 0.05),
+            ".*_calf_joint": NoisyValue(-1.5, 0.05),
+        },
+        kp=NoisyValue(20, 3.0),  # +/- 3.0
+        kv=NoisyValue(0.5, 0.15),  # +/- 0.15
+        damping=NoisyValue(2.0, 0.5),  # +/- 0.5
+        frictionloss=NoisyValue(0.2, 0.1),  # +/- 0.1
+    )
+
+    # Set 0.01 noise on all observations
+    ObservationManager(
+        self,
+        cfg={
+            # ...
+            "angle_velocity": {
+                "fn": lambda env: self.robot_manager.get_angular_velocity(),
+                "noise": 0.05, # IMU gyroscope noise: ~0.05-0.2 rad/s
+            },
+            # ...
+        }
+    }
+```
+
+## Training
+
+We will be training the robot with the [rsl_rl](https://github.com/leggedrobotics/rsl_rl) training library. So first, we need to install that and tensorboard:
+
+```bash
+pip install tensorboard rsl-rl-lib>=2.2.4
+```
+
+Now you can run the training with:
+
+```bash
+python ./train.py
+```
+
+You can view the training progress with:
+
+```bash
+tensorboard --logdir ./logs/
+```
+
+The Genesis Forge training environment will also save videos while training that can be viewed in `./logs/go2-randomization/videos`.
+
+## Evaluation
+
+Now you can view the trained policy:
+
+```bash
+python ./eval.py ./logs/go2-randomization/
+```

--- a/examples/domain_randomization/README.md
+++ b/examples/domain_randomization/README.md
@@ -42,8 +42,8 @@ Here are the relevant snippets:
         },
         kp=NoisyValue(20, 3.0),  # +/- 3.0
         kv=NoisyValue(0.5, 0.15),  # +/- 0.15
-        damping=NoisyValue(2.0, 0.5),  # +/- 0.5
-        frictionloss=NoisyValue(0.2, 0.1),  # +/- 0.1
+        damping=NoisyValue(0.5, 0.25),  # +/- 0.25
+        frictionloss=NoisyValue(0.15, 0.1),  # +/- 0.1
     )
 
     # Set 0.01 noise on all observations

--- a/examples/domain_randomization/environment.py
+++ b/examples/domain_randomization/environment.py
@@ -1,29 +1,25 @@
-import torch
 import genesis as gs
 
 from genesis_forge import ManagedEnvironment
 from genesis_forge.managers import (
+    ActuatorManager,
     RewardManager,
     TerminationManager,
     EntityManager,
     ObservationManager,
-    ActuatorManager,
     PositionActionManager,
     VelocityCommandManager,
-    ContactManager,
 )
-from genesis_forge.mdp import reset, rewards, terminations, observations
-
-from gait_command_manager import GaitCommandManager
+from genesis_forge.managers.actuator import NoisyValue
+from genesis_forge.mdp import reset, rewards, terminations
 
 
 HEIGHT_OFFSET = 0.4
 INITIAL_BODY_POSITION = [0.0, 0.0, HEIGHT_OFFSET]
 INITIAL_QUAT = [1.0, 0.0, 0.0, 0.0]
-CURRICULUM_CHECK_EVERY_STEPS = 100
 
 
-class Go2GaitTrainingEnv(ManagedEnvironment):
+class Go2CommandDirectionEnv(ManagedEnvironment):
     """
     Example training environment for the Go2 robot.
     """
@@ -34,16 +30,13 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
         dt: float = 1 / 50,  # control frequency on real robot is 50hz
         max_episode_length_s: int | None = 20,
         headless: bool = True,
-        gamepad_control: bool = False,
     ):
         super().__init__(
             num_envs=num_envs,
             dt=dt,
             max_episode_length_sec=max_episode_length_s,
-            max_episode_random_scaling=0.4,
+            max_episode_random_scaling=0.1,
         )
-        self._gamepad_control = gamepad_control
-        self._next_curriculum_check_step = CURRICULUM_CHECK_EVERY_STEPS
 
         # Construct the scene
         self.scene = gs.Scene(
@@ -61,7 +54,9 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
                 constraint_solver=gs.constraint_solver.Newton,
                 enable_collision=True,
                 enable_joint_limit=True,
-                max_collision_pairs=60,
+                # for this locomotion policy there are usually no more than 30 collision pairs
+                # set a low value can save memory
+                max_collision_pairs=30,
             ),
         )
 
@@ -74,20 +69,19 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
                 file="urdf/go2/urdf/go2.urdf",
                 pos=INITIAL_BODY_POSITION,
                 quat=INITIAL_QUAT,
-                links_to_keep=["FL_foot", "FR_foot", "RL_foot", "RR_foot"],
             ),
         )
 
         # Camera, for headless video recording
         self.camera = self.scene.add_camera(
-            pos=(2.5, 1.5, 1.0),
+            pos=(-2.5, -1.5, 1.0),
             lookat=(0.0, 0.0, 0.0),
             res=(1280, 720),
             fov=40,
             env_idx=0,
             debug=True,
-            GUI=self._gamepad_control,
         )
+        self.camera.follow_entity(self.robot)
 
     def config(self):
         """
@@ -109,6 +103,14 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
                         "zero_velocity": True,
                     },
                 },
+                # Randomly add/subtract mass to the robot's body
+                "mass": {
+                    "fn": reset.randomize_link_mass_shift,
+                    "params": {
+                        "link_name": "base",
+                        "add_mass_range": [-0.5, 0.5],
+                    },
+                },
             },
         )
 
@@ -116,45 +118,27 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
         # Joint Actions
         self.actuator_manager = ActuatorManager(
             self,
-            joint_names=[
-                "FL_.*_joint",
-                "FR_.*_joint",
-                "RL_.*_joint",
-                "RR_.*_joint",
-            ],
+            joint_names=[".*"],
             default_pos={
-                ".*_hip_joint": 0.0,
-                "FL_thigh_joint": 0.8,
-                "FR_thigh_joint": 0.8,
-                "RL_thigh_joint": 1.0,
-                "RR_thigh_joint": 1.0,
-                ".*_calf_joint": -1.5,
+                # Randomize the default positions by +/- 0.1 radians
+                ".*_hip_joint": NoisyValue(0.0, 0.05),
+                "FL_thigh_joint": NoisyValue(0.8, 0.05),
+                "FR_thigh_joint": NoisyValue(0.8, 0.05),
+                "RL_thigh_joint": NoisyValue(1.0, 0.05),
+                "RR_thigh_joint": NoisyValue(1.0, 0.05),
+                ".*_calf_joint": NoisyValue(-1.5, 0.05),
             },
-            kp=20,
-            kv=0.5,
+            kp=NoisyValue(20, 3.0),  # +/- 3.0
+            kv=NoisyValue(0.5, 0.15),  # +/- 0.15
+            damping=NoisyValue(1.0, 0.5),  # +/- 0.5
+            frictionloss=NoisyValue(0.2, 0.1),  # +/- 0.1
         )
         self.action_manager = PositionActionManager(
             self,
             scale=0.25,
+            delay_step=1,
             use_default_offset=True,
             actuator_manager=self.actuator_manager,
-        )
-
-        ##
-        # Contact manager
-        self.foot_contact_manager = ContactManager(
-            self,
-            link_names=[".*_foot"],
-            air_time_contact_threshold=1.0,
-        )
-        self.body_contact_manager = ContactManager(
-            self,
-            link_names=["base"],
-            air_time_contact_threshold=1.0,
-        )
-        self.bad_contact_manager = ContactManager(
-            self,
-            link_names=[".*_thigh", ".*_calf"],
         )
 
         ##
@@ -163,48 +147,28 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
             self,
             range={
                 "lin_vel_x": [-1.0, 1.0],
-                "lin_vel_y": [0.0, 0.0],
+                "lin_vel_y": [-1.0, 1.0],
                 "ang_vel_z": [-1.0, 1.0],
             },
-            standing_probability=0.00,
-            resample_time_sec=3.0,
-        )
-
-        ##
-        # Gait command manager
-        self.gait_command_manager = GaitCommandManager(
-            self,
-            foot_names={
-                "FL": "FL_foot",
-                "FR": "FR_foot",
-                "RL": "RL_foot",
-                "RR": "RR_foot",
+            standing_probability=0.02,
+            resample_time_sec=5.0,
+            debug_visualizer=True,
+            debug_visualizer_cfg={
+                "envs_idx": [0],
             },
-            resample_time_sec=4.0,
         )
 
         ##
         # Rewards
-        self.reward_manager = RewardManager(
+        RewardManager(
             self,
             logging_enabled=True,
             cfg={
-                "gait_phase_reward": {
-                    "weight": 1.5,
-                    "fn": self.gait_command_manager.gait_phase_reward,
-                    "params": {
-                        "contact_manager": self.foot_contact_manager,
-                    },
-                },
-                "foot_height_reward": {
-                    "weight": 0.9,
-                    "fn": self.gait_command_manager.foot_height_reward,
-                },
                 "base_height_target": {
-                    "weight": -25.0,
+                    "weight": -50.0,
                     "fn": rewards.base_height,
                     "params": {
-                        "target_height": 0.35,
+                        "target_height": 0.3,
                         "entity_attr": "robot",
                     },
                 },
@@ -224,29 +188,22 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
                         "entity_manager": self.robot_manager,
                     },
                 },
-                "body_acceleration": {
-                    "weight": -0.1,
-                    "fn": rewards.body_acceleration_exp,
-                    "params": {
-                        "entity_manager": self.robot_manager,
-                    },
-                },
                 "lin_vel_z": {
-                    "weight": -0.1,
+                    "weight": -1.0,
                     "fn": rewards.lin_vel_z_l2,
                     "params": {
                         "entity_manager": self.robot_manager,
                     },
                 },
                 "action_rate": {
-                    "weight": -0.01,
+                    "weight": -0.005,
                     "fn": rewards.action_rate_l2,
                 },
-                "bad_contact": {
-                    "weight": -1.0,
-                    "fn": rewards.contact_force,
+                "similar_to_default": {
+                    "weight": -0.1,
+                    "fn": rewards.dof_similar_to_default,
                     "params": {
-                        "contact_manager": self.bad_contact_manager,
+                        "action_manager": self.action_manager,
                     },
                 },
             },
@@ -267,16 +224,8 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
                 "fall_over": {
                     "fn": terminations.bad_orientation,
                     "params": {
-                        "limit_angle": 20.0,
+                        "limit_angle": 10.0,
                         "entity_manager": self.robot_manager,
-                    },
-                },
-                # Terminate if the body falls over
-                "body_contact": {
-                    "fn": terminations.contact_force,
-                    "params": {
-                        "contact_manager": self.body_contact_manager,
-                        "threshold": 1.0,
                     },
                 },
             },
@@ -286,100 +235,34 @@ class Go2GaitTrainingEnv(ManagedEnvironment):
         # Observations
         ObservationManager(
             self,
-            name="policy",
-            history_len=5,
             cfg={
-                "gait_command": {
-                    "fn": self.gait_command_manager.observation,
-                },
                 "velocity_cmd": {
                     "fn": self.velocity_command.observation,
                 },
                 "angle_velocity": {
                     "fn": lambda env: self.robot_manager.get_angular_velocity(),
+                    "noise": 0.05,
                 },
                 "linear_velocity": {
                     "fn": lambda env: self.robot_manager.get_linear_velocity(),
+                    "noise": 0.1,
                 },
                 "projected_gravity": {
                     "fn": lambda env: self.robot_manager.get_projected_gravity(),
+                    "noise": 0.05,
                 },
                 "dof_position": {
                     "fn": lambda env: self.action_manager.get_dofs_position(),
+                    "noise": 0.01,
                 },
                 "dof_velocity": {
                     "fn": lambda env: self.action_manager.get_dofs_velocity(),
-                    "scale": 0.05,
+                    "scale": 0.02,
+                    "noise": 0.1,
                 },
                 "actions": {
                     "fn": lambda env: self.action_manager.get_actions(),
+                    "noise": 0.01,
                 },
             },
         )
-        # Priviledged observations for the "critic" policy
-        # The "policy" observations will also be included with these observations by rsl_rl via the obs_groups config.
-        # You can keep the observation groups entirely separate by setting obs_groups to {"policy": ["policy"], "critic": ["critic"]}
-        ObservationManager(
-            self,
-            name="critic",
-            history_len=5,
-            cfg={
-                "foot_contact_force": {
-                    "fn": observations.contact_force,
-                    "params": {
-                        "contact_manager": self.foot_contact_manager,
-                    },
-                },
-                "dof_force": {
-                    "fn": observations.entity_dofs_force,
-                    "params": {
-                        "action_manager": self.action_manager,
-                    },
-                    "scale": 0.1,
-                },
-            },
-        )
-
-    def build(self):
-        super().build()
-        self.camera.follow_entity(self.robot)
-
-    def step(self, actions: torch.Tensor):
-        # Render the camera if not headless
-        if self._gamepad_control:
-            self.camera.render()
-        return super().step(actions)
-
-    def reset(self, envs_idx: list[int] | None = None):
-        reset = super().reset(envs_idx)
-        if envs_idx is not None:
-            self.update_curriculum()
-        return reset
-
-    def update_curriculum(self):
-        """
-        Check the curriculum
-        """
-        # Limit how often we check/update the curriculum
-        if self.step_count < self._next_curriculum_check_step:
-            return
-        self._next_curriculum_check_step = (
-            self.step_count + CURRICULUM_CHECK_EVERY_STEPS
-        )
-
-        # Gait phase
-        # Increase gaits and period range if the base gait reward is over 0.7
-        gait_phase_reward = self.reward_manager.last_episode_mean_reward(
-            "gait_phase_reward", before_weight=True
-        )
-        if gait_phase_reward > 0.75:
-            self.gait_command_manager.increment_num_gaits()
-            self.gait_command_manager.increment_gait_period_range()
-
-        # Foot clearance
-        # Increase foot clearance range, if the base reward is over 0.8
-        foot_height_reward = self.reward_manager.last_episode_mean_reward(
-            "foot_height_reward", before_weight=True
-        )
-        if foot_height_reward > 0.8:
-            self.gait_command_manager.increment_foot_clearance_range()

--- a/examples/domain_randomization/environment.py
+++ b/examples/domain_randomization/environment.py
@@ -145,7 +145,6 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
         self.action_manager = PositionActionManager(
             self,
             scale=0.25,
-            delay_step=1,
             use_default_offset=True,
             actuator_manager=self.actuator_manager,
         )
@@ -244,7 +243,6 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
         # Observations
         ObservationManager(
             self,
-            history_len=2,
             cfg={
                 "velocity_cmd": {
                     "fn": self.velocity_command.observation,
@@ -271,7 +269,7 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                     "noise": 0.01,
                 },
                 "actions": {
-                    "fn": lambda env: self.action_manager.raw_actions,
+                    "fn": lambda env: self.action_manager.get_actions(),
                 },
             },
         )

--- a/examples/domain_randomization/environment.py
+++ b/examples/domain_randomization/environment.py
@@ -244,6 +244,7 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
         # Observations
         ObservationManager(
             self,
+            history_len=2,
             cfg={
                 "velocity_cmd": {
                     "fn": self.velocity_command.observation,

--- a/examples/domain_randomization/environment.py
+++ b/examples/domain_randomization/environment.py
@@ -1,3 +1,4 @@
+import torch
 import genesis as gs
 
 from genesis_forge import ManagedEnvironment
@@ -57,6 +58,14 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 # for this locomotion policy there are usually no more than 30 collision pairs
                 # set a low value can save memory
                 max_collision_pairs=30,
+                #
+                # Batching must be enabled to enable domain randomization of the DOF armature settings.
+                # Enabling these settings will SIGNIFICANTLY slow down the simulation,
+                # but will also increase the randomization across all envs.
+                # Uncomment the following 3 lines to enable this:
+                # batch_dofs_info=True,
+                # batch_joints_info=True,
+                # batch_links_info=True,
             ),
         )
 
@@ -103,12 +112,12 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                         "zero_velocity": True,
                     },
                 },
-                # Randomly add/subtract mass to the robot's body
+                # Add/subtract a random amount of mass to the robot's body
                 "mass": {
                     "fn": reset.randomize_link_mass_shift,
                     "params": {
                         "link_name": "base",
-                        "add_mass_range": [-0.5, 0.5],
+                        "mass_range": [-0.5, 1.0],  # kg
                     },
                 },
             },
@@ -120,18 +129,18 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
             self,
             joint_names=[".*"],
             default_pos={
-                # Randomize the default positions by +/- 0.1 radians
-                ".*_hip_joint": NoisyValue(0.0, 0.05),
-                "FL_thigh_joint": NoisyValue(0.8, 0.05),
-                "FR_thigh_joint": NoisyValue(0.8, 0.05),
-                "RL_thigh_joint": NoisyValue(1.0, 0.05),
-                "RR_thigh_joint": NoisyValue(1.0, 0.05),
-                ".*_calf_joint": NoisyValue(-1.5, 0.05),
+                # Randomize the default positions by +/- 0.05 radians
+                ".*_hip_joint": NoisyValue(0.0, 0.02),
+                "FL_thigh_joint": NoisyValue(0.8, 0.02),
+                "FR_thigh_joint": NoisyValue(0.8, 0.02),
+                "RL_thigh_joint": NoisyValue(1.0, 0.02),
+                "RR_thigh_joint": NoisyValue(1.0, 0.02),
+                ".*_calf_joint": NoisyValue(-1.5, 0.02),
             },
-            kp=NoisyValue(20, 3.0),  # +/- 3.0
-            kv=NoisyValue(0.5, 0.15),  # +/- 0.15
-            damping=NoisyValue(1.0, 0.5),  # +/- 0.5
-            frictionloss=NoisyValue(0.2, 0.1),  # +/- 0.1
+            kp=NoisyValue(25, 2.0),  # +/- 2.0
+            kv=NoisyValue(0.5, 0.05),  # +/- 0.05
+            damping=NoisyValue(2.0, 0.05),  # +/- 0.05
+            frictionloss=NoisyValue(0.2, 0.05),  # +/- 0.05
         )
         self.action_manager = PositionActionManager(
             self,
@@ -224,7 +233,7 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 "fall_over": {
                     "fn": terminations.bad_orientation,
                     "params": {
-                        "limit_angle": 10.0,
+                        "limit_angle": 15.0,
                         "entity_manager": self.robot_manager,
                     },
                 },
@@ -241,15 +250,15 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 },
                 "angle_velocity": {
                     "fn": lambda env: self.robot_manager.get_angular_velocity(),
-                    "noise": 0.05,
+                    "noise": 0.01,
                 },
                 "linear_velocity": {
                     "fn": lambda env: self.robot_manager.get_linear_velocity(),
-                    "noise": 0.1,
+                    "noise": 0.01,
                 },
                 "projected_gravity": {
                     "fn": lambda env: self.robot_manager.get_projected_gravity(),
-                    "noise": 0.05,
+                    "noise": 0.01,
                 },
                 "dof_position": {
                     "fn": lambda env: self.action_manager.get_dofs_position(),
@@ -258,11 +267,10 @@ class Go2CommandDirectionEnv(ManagedEnvironment):
                 "dof_velocity": {
                     "fn": lambda env: self.action_manager.get_dofs_velocity(),
                     "scale": 0.02,
-                    "noise": 0.1,
+                    "noise": 0.01,
                 },
                 "actions": {
-                    "fn": lambda env: self.action_manager.get_actions(),
-                    "noise": 0.01,
+                    "fn": lambda env: self.action_manager.raw_actions,
                 },
             },
         )

--- a/examples/domain_randomization/eval.py
+++ b/examples/domain_randomization/eval.py
@@ -1,0 +1,89 @@
+import os
+import glob
+import torch
+import pickle
+import argparse
+from importlib import metadata
+import genesis as gs
+
+from genesis_forge.wrappers import RslRlWrapper
+from environment import Go2CommandDirectionEnv
+
+try:
+    try:
+        if metadata.version("rsl-rl"):
+            raise ImportError
+    except metadata.PackageNotFoundError:
+        if metadata.version("rsl-rl-lib").startswith("1."):
+            raise ImportError
+except (metadata.PackageNotFoundError, ImportError) as e:
+    raise ImportError("Please install install 'rsl-rl-lib>=2.2.4'.") from e
+from rsl_rl.runners import OnPolicyRunner
+
+EXPERIMENT_NAME = "go2-randomization"
+
+parser = argparse.ArgumentParser(add_help=True)
+parser.add_argument("-d", "--device", type=str, default="gpu")
+parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
+args = parser.parse_args()
+
+
+def get_latest_model(log_dir: str) -> str:
+    """
+    Get the last model from the log directory
+    """
+    model_checkpoints = glob.glob(os.path.join(log_dir, "model_*.pt"))
+    if len(model_checkpoints) == 0:
+        print(
+            f"Warning: No model files found at '{log_dir}' (you might need to train more)."
+        )
+        exit(1)
+    # Sort by the file with the highest number
+    sorted_models = sorted(
+        model_checkpoints,
+        key=lambda x: int(os.path.basename(x).split("_")[1].split(".")[0]),
+    )
+    return sorted_models[-1]
+
+
+def main():
+    # Processor backend (GPU or CPU)
+    backend = gs.gpu
+    if args.device == "cpu":
+        backend = gs.cpu
+        torch.set_default_device("cpu")
+    gs.init(logging_level="warning", backend=backend)
+
+    # Load training configuration
+    log_path = f"./logs/{args.exp_name}"
+    [cfg] = pickle.load(open(f"{log_path}/cfgs.pkl", "rb"))
+    model = get_latest_model(log_path)
+
+    # Setup environment
+    env = Go2CommandDirectionEnv(num_envs=1, headless=False)
+    env = RslRlWrapper(env)
+    env.build()
+
+    # Eval
+    print("🎬 Loading last model...")
+    runner = OnPolicyRunner(env, cfg, log_path, device=gs.device)
+    runner.load(model)
+    policy = runner.get_inference_policy(device=gs.device)
+
+    obs, _ = env.reset()
+    try:
+        with torch.no_grad():
+            while True:
+                actions = policy(obs)
+                obs, _rews, _dones, _infos = env.step(actions)
+    except KeyboardInterrupt:
+        pass
+    except gs.GenesisException as e:
+        if e.message != "Viewer closed.":
+            raise e
+    except Exception as e:
+        raise e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/domain_randomization/train.py
+++ b/examples/domain_randomization/train.py
@@ -1,0 +1,134 @@
+import os
+import copy
+import torch
+import shutil
+import pickle
+import argparse
+from importlib import metadata
+import genesis as gs
+
+from genesis_forge.wrappers import (
+    VideoWrapper,
+    RslRlWrapper,
+)
+from environment import Go2CommandDirectionEnv
+
+try:
+    try:
+        if metadata.version("rsl-rl"):
+            raise ImportError
+    except metadata.PackageNotFoundError:
+        if metadata.version("rsl-rl-lib").startswith("1."):
+            raise ImportError
+except (metadata.PackageNotFoundError, ImportError) as e:
+    raise ImportError("Please install install 'rsl-rl-lib>=2.2.4'.") from e
+from rsl_rl.runners import OnPolicyRunner
+
+EXPERIMENT_NAME = "go2-randomization"
+
+parser = argparse.ArgumentParser(add_help=True)
+parser.add_argument("-n", "--num_envs", type=int, default=4096)
+parser.add_argument("--max_iterations", type=int, default=220)
+parser.add_argument("-d", "--device", type=str, default="gpu")
+parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
+args = parser.parse_args()
+
+
+def training_cfg(exp_name: str, max_iterations: int):
+    return {
+        "algorithm": {
+            "class_name": "PPO",
+            "clip_param": 0.2,
+            "desired_kl": 0.01,
+            "entropy_coef": 0.01,
+            "gamma": 0.99,
+            "lam": 0.95,
+            "learning_rate": 0.001,
+            "max_grad_norm": 1.0,
+            "num_learning_epochs": 5,
+            "num_mini_batches": 4,
+            "schedule": "adaptive",
+            "use_clipped_value_loss": True,
+            "value_loss_coef": 1.0,
+        },
+        "init_member_classes": {},
+        "policy": {
+            "activation": "elu",
+            "actor_hidden_dims": [512, 256, 128],
+            "critic_hidden_dims": [512, 256, 128],
+            "init_noise_std": 1.0,
+            "class_name": "ActorCritic",
+        },
+        "runner": {
+            "checkpoint": -1,
+            "experiment_name": exp_name,
+            "load_run": -1,
+            "log_interval": 1,
+            "max_iterations": max_iterations,
+            "record_interval": -1,
+            "resume": False,
+            "resume_path": None,
+            "run_name": "",
+        },
+        "runner_class_name": "OnPolicyRunner",
+        "seed": 1,
+        "num_steps_per_env": 24,
+        "save_interval": 100,
+        "empirical_normalization": None,
+        "obs_groups": {"policy": ["policy"], "critic": ["policy"]},
+    }
+
+
+def main():
+    # Initialize Genesis
+    # Processor backend (GPU or CPU)
+    backend = gs.gpu
+    if args.device == "cpu":
+        backend = gs.cpu
+        torch.set_default_device("cpu")
+    gs.init(logging_level="warning", backend=backend, performance_mode=True)
+
+    # Logging directory
+    log_base_dir = "./logs"
+    experiment_name = args.exp_name
+    log_path = os.path.join(log_base_dir, experiment_name)
+    if os.path.exists(log_path):
+        shutil.rmtree(log_path)
+    os.makedirs(log_path, exist_ok=True)
+    print(f"Logging to: {log_path}")
+
+    # Load training configuration and save snapshot of training configs
+    cfg = training_cfg(experiment_name, args.max_iterations)
+    pickle.dump(
+        [cfg],
+        open(os.path.join(log_path, "cfgs.pkl"), "wb"),
+    )
+
+    # Create environment
+    env = Go2CommandDirectionEnv(num_envs=args.num_envs, headless=True)
+
+    # Record videos in regular intervals
+    env = VideoWrapper(
+        env,
+        video_length_sec=12,
+        out_dir=os.path.join(log_path, "videos"),
+        episode_trigger=lambda episode_id: episode_id % 2 == 0,
+    )
+
+    # Build the environment
+    env = RslRlWrapper(env)
+    env.build()
+    env.reset()
+
+    # Train
+    print("💪 Training model...")
+    runner = OnPolicyRunner(env, copy.deepcopy(cfg), log_path, device=gs.device)
+    runner.git_status_repos = ["."]
+    runner.learn(
+        num_learning_iterations=args.max_iterations, init_at_random_ep_len=False
+    )
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/domain_randomization/train.py
+++ b/examples/domain_randomization/train.py
@@ -28,7 +28,7 @@ EXPERIMENT_NAME = "go2-randomization"
 
 parser = argparse.ArgumentParser(add_help=True)
 parser.add_argument("-n", "--num_envs", type=int, default=4096)
-parser.add_argument("--max_iterations", type=int, default=220)
+parser.add_argument("--max_iterations", type=int, default=250)
 parser.add_argument("-d", "--device", type=str, default="gpu")
 parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
 args = parser.parse_args()

--- a/examples/rough_terrain/environment.py
+++ b/examples/rough_terrain/environment.py
@@ -110,7 +110,7 @@ class Go2RoughTerrainEnv(ManagedEnvironment):
 
         ##
         # Joint Actions
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[
                 "FL_.*_joint",
@@ -126,11 +126,15 @@ class Go2RoughTerrainEnv(ManagedEnvironment):
                 "RR_thigh_joint": 1.0,
                 ".*_calf_joint": -1.5,
             },
+            kp=20,
+            kv=0.5,
+            max_force=23.5,
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.25,
             use_default_offset=True,
-            pd_kp=20,
-            pd_kv=0.5,
-            max_force=23.5,
+            actuator_manager=self.actuator_manager,
         )
 
         ##

--- a/examples/simple/environment.py
+++ b/examples/simple/environment.py
@@ -11,6 +11,7 @@ from genesis_forge.managers import (
     TerminationManager,
     EntityManager,
     ObservationManager,
+    ActuatorManager,
     PositionActionManager,
 )
 from genesis_forge.mdp import reset, rewards, terminations
@@ -117,7 +118,7 @@ class Go2SimpleEnv(ManagedEnvironment):
 
         ##
         # Joint Actions
-        self.action_manager = PositionActionManager(
+        self.actuator_manager = ActuatorManager(
             self,
             joint_names=[
                 "FL_.*_joint",
@@ -133,11 +134,15 @@ class Go2SimpleEnv(ManagedEnvironment):
                 "RR_thigh_joint": 1.0,
                 ".*_calf_joint": -1.5,
             },
+            kp=20,
+            kv=0.5,
+        )
+        self.action_manager = PositionActionManager(
+            self,
             scale=0.25,
             clip=(-100.0, 100.0),
             use_default_offset=True,
-            pd_kp=20,
-            pd_kv=0.5,
+            actuator_manager=self.actuator_manager,
         )
 
         ##

--- a/genesis_forge/managed_env.py
+++ b/genesis_forge/managed_env.py
@@ -14,10 +14,12 @@ from genesis_forge.managers import (
     ObservationManager,
     RewardManager,
     TerminationManager,
+    ActuatorManager,
 )
 
 
 class ManagersDict(TypedDict):
+    actuator: ActuatorManager | None
     contact: list[ContactManager]
     entity: list[EntityManager]
     command: list[CommandManager]
@@ -132,6 +134,7 @@ class ManagedEnvironment(GenesisEnv):
             "command": [],
             "terrain": [],
             # there can only be one of each of these
+            "actuator": None,
             "action": None,
             "observation": [],
             "reward": None,
@@ -256,6 +259,8 @@ class ManagedEnvironment(GenesisEnv):
 
         for terrain_manager in self.managers["terrain"]:
             terrain_manager.build()
+        if self.managers["actuator"] is not None:
+            self.managers["actuator"].build()
         if self.managers["action"] is not None:
             self.managers["action"].build()
         for contact_manager in self.managers["contact"]:
@@ -348,6 +353,8 @@ class ManagedEnvironment(GenesisEnv):
         """
         (obs, _) = super().reset(env_ids)
 
+        if self.managers["actuator"] is not None:
+            self.managers["actuator"].reset(env_ids)
         if self.managers["action"] is not None:
             self.managers["action"].reset(env_ids)
         for entity_manager in self.managers["entity"]:

--- a/genesis_forge/managers/__init__.py
+++ b/genesis_forge/managers/__init__.py
@@ -8,6 +8,7 @@ from .contact import ContactManager
 from .terrain_manager import TerrainManager
 from .entity_manager import EntityManager
 from .observation_manager import ObservationManager
+from .actuator import ActuatorManager
 from .config import (
     MdpFnClass,
     ResetMdpFnClass,
@@ -27,4 +28,5 @@ __all__ = [
     "ObservationManager",
     "MdpFnClass",
     "ResetMdpFnClass",
+    "ActuatorManager",
 ]

--- a/genesis_forge/managers/action/position_action_manager.py
+++ b/genesis_forge/managers/action/position_action_manager.py
@@ -5,7 +5,7 @@ import genesis as gs
 import numpy as np
 from gymnasium import spaces
 from typing import Any, Callable, TypeVar
-
+from deprecated import deprecated
 from genesis_forge.genesis_env import GenesisEnv
 from genesis_forge.managers.action.base import BaseActionManager
 from genesis_forge.values import ensure_dof_pattern
@@ -217,8 +217,14 @@ class PositionActionManager(BaseActionManager):
     DOF Getters
     """
 
+    @deprecated(
+        version="0.3,0",
+        reason="Use the actuator manager directly.",
+    )
     def get_dofs_position(self, noise: float = 0.0):
         """
+        Deprecated: Use the actuator manager directly.
+
         Return the current position of the enabled DOFs.
         This is a wrapper for `RigidEntity.get_dofs_position`.
 
@@ -227,8 +233,14 @@ class PositionActionManager(BaseActionManager):
         """
         return self._actuator_manager.get_dofs_position(noise)
 
+    @deprecated(
+        version="0.3,0",
+        reason="Use the actuator manager directly.",
+    )
     def get_dofs_velocity(self, noise: float = 0.0, clip: tuple[float, float] = None):
         """
+        Deprecated: Use the actuator manager directly.
+
         Return the current velocity of the enabled DOFs.
         This is a wrapper for `RigidEntity.get_dofs_velocity`.
 
@@ -238,8 +250,14 @@ class PositionActionManager(BaseActionManager):
         """
         return self._actuator_manager.get_dofs_velocity(noise, clip)
 
+    @deprecated(
+        version="0.3,0",
+        reason="Use the actuator manager directly.",
+    )
     def get_dofs_force(self, noise: float = 0.0, clip_to_max_force: bool = False):
         """
+        Deprecated: Use the actuator manager directly.
+
         Return the force experienced by the enabled DOFs.
         This is a wrapper for `RigidEntity.get_dofs_force`.
 

--- a/genesis_forge/managers/action/position_action_manager.py
+++ b/genesis_forge/managers/action/position_action_manager.py
@@ -7,37 +7,23 @@ from gymnasium import spaces
 from typing import Any, Callable, TypeVar
 
 from genesis_forge.genesis_env import GenesisEnv
-from genesis_forge.managers.base import BaseManager
 from genesis_forge.managers.action.base import BaseActionManager
+from genesis_forge.values import ensure_dof_pattern
+from genesis_forge.managers.actuator import ActuatorManager
+
+deprecated_arg_names = [
+    "joint_names",
+    "default_pos",
+    "pd_kp",
+    "pd_kv",
+    "max_force",
+    "damping",
+    "stiffness",
+    "frictionloss",
+    "noise_scale",
+]
 
 T = TypeVar("T")
-DofValue = dict[str, T] | T
-"""Mapping of DOF name (literal or regex) to value."""
-
-
-def _ensure_dof_pattern(value: DofValue) -> dict[str, Any] | None:
-    """
-    Ensures the value is a dictionary in the form: {<joint name or regex>: <value>}.
-
-    Example:
-        >>> ensure_dof_pattern(50)
-        {".*": 50}
-        >>> ensure_dof_pattern({".*": 50})
-        {".*": 50}
-        >>> ensure_dof_pattern({"knee_joint": 50})
-        {"knee_joint": 50}
-
-    Args:
-        value: The value to convert.
-
-    Returns:
-        A dictionary of DOF name pattern to value.
-    """
-    if value is None:
-        return None
-    if isinstance(value, dict):
-        return value
-    return {".*": value}
 
 
 class PositionActionManager(BaseActionManager):
@@ -52,23 +38,12 @@ class PositionActionManager(BaseActionManager):
 
     Args:
         env: The environment to manage the DOF actuators for.
-        joint_names: The joint names to manage.
-        default_pos: The default DOF positions.
+        actuator_manager: The actuator manager which is used to setup and control the DOF joints.
         scale: How much to scale the action.
         offset: Offset factor for the action.
         use_default_offset: Whether to use default joint positions configured in the articulation asset as offset. Defaults to True.
         clip: Clip the action values to the range. If omitted, the action values will automatically be clipped to the joint limits.
-        pd_kp: The PD kp values.
-        pd_kv: The PD kv values.
-        max_force: The max force values.
-        damping: The damping values.
-        stiffness: The stiffness values.
-        frictionloss: The frictionloss values.
-        noise_scale: The scale of the random noise to add to the actuator settings (kp, kv, damping, etc) at reset.
-        reset_random_scale: Scale all DOF values on reset by this amount +/-.
         quiet_action_errors: Whether to quiet action errors.
-        randomization_cfg: The randomization configuration used to randomize the DOF values across all environments and between resets.
-        resample_randomization_s: The time interval to resample the randomization values.
         delay_step: The number of steps to delay the actions for.
                     This is an easy way to emulate the latency in the system.
 
@@ -80,23 +55,20 @@ class PositionActionManager(BaseActionManager):
                 # ...define scene and robot...
 
             def config(self):
+                self.actuator_manager = ActuatorManager(
+                    self,
+                    joint_names=".*",
+                    default_pos={".*": 0.0},
+                    kp=50,
+                    kv=0.5,
+                    max_force=8.0,
+                )
                 self.action_manager = PositionActionManager(
                     self,
                     joint_names=".*",
                     scale=0.5,
                     use_default_offset=True,
-                    default_pos={
-                        # Hip joints
-                        "Leg[1-2]_Hip": -1.0,
-                        "Leg[3-4]_Hip": 1.0,
-                        # Femur joints
-                        "Leg[1-4]_Femur": 0.5,
-                        # Tibia joints
-                        "Leg[1-4]_Tibia": 0.6,
-                    },
-                    pd_kp=50,
-                    pd_kv=0.5,
-                    max_force=8.0,
+                    actuator_manager=self.actuator_manager,
                 )
 
     Example using the manager directly::
@@ -106,30 +78,25 @@ class PositionActionManager(BaseActionManager):
                 super().__init__(*args, **kwargs)
                 # ...define scene and robot...
 
-            def config(self):
-                self.action_manager = PositionActionManager(
+                self.actuator_manager = ActuatorManager(
                     self,
                     joint_names=".*",
-                    action_scale=0.5,
-                    action_offset=0.0,
-                    use_default_offset=True,
-                    default_pos={
-                        # Hip joints
-                        "Leg[1-2]_Hip": -1.0,
-                        "Leg[3-4]_Hip": 1.0,
-                        # Femur joints
-                        "Leg[1-4]_Femur": 0.5,
-                        # Tibia joints
-                        "Leg[1-4]_Tibia": 0.6,
-                    },
-                    pd_kp=50,
-                    pd_kv=0.5,
+                    default_pos={".*": 0.0},
+                    kp=50,
+                    kv=0.5,
                     max_force=8.0,
+                )
+                self.action_manager = PositionActionManager(
+                    self,
+                    scale=0.5,
+                    offset=0.0,
+                    use_default_offset=True,
                 )
 
             def build(self):
                 super().build()
-                config()
+                self.actuator_manager.build()
+                self.action_manager.build()
 
             step(self, actions: torch.Tensor) -> None:
                 super().step(actions)
@@ -139,6 +106,7 @@ class PositionActionManager(BaseActionManager):
 
             reset(self, envs_idx: list[int] = None) -> None:
                 super().reset(envs_idx)
+                self.actuator_manager.reset(envs_idx)
                 self.action_manager.reset(envs_idx)
 
                 # ...do other reset things...
@@ -149,56 +117,75 @@ class PositionActionManager(BaseActionManager):
     def __init__(
         self,
         env: GenesisEnv,
-        joint_names: list[str] | str = ".*",
-        default_pos: DofValue[float] = {".*": 0.0},
-        scale: DofValue[float] = 1.0,
-        clip: DofValue[tuple[float, float]] = None,
-        offset: DofValue[float] = 0.0,
+        actuator_manager: ActuatorManager | None = None,
+        scale: float | dict[str, float] = 1.0,
+        offset: float | dict[str, float] = 0.0,
+        clip: tuple[float, float] | dict[str, tuple[float, float]] = None,
         use_default_offset: bool = True,
-        pd_kp: DofValue[float] = None,
-        pd_kv: DofValue[float] = None,
-        max_force: DofValue[float | tuple[float, float]] = None,
-        damping: DofValue[float] = None,
-        stiffness: DofValue[float] = None,
-        frictionloss: DofValue[float] = None,
-        noise_scale: float = 0.0,
         action_handler: Callable[[torch.Tensor], None] = None,
         quiet_action_errors: bool = False,
         delay_step: int = 0,
+        **kwargs,
     ):
         super().__init__(env, delay_step)
-        self._has_initialized = False
-        self._default_pos_cfg = _ensure_dof_pattern(default_pos)
-        self._offset_cfg = _ensure_dof_pattern(offset)
-        self._scale_cfg = _ensure_dof_pattern(scale)
-        self._clip_cfg = _ensure_dof_pattern(clip)
-        self._pd_kp_cfg = _ensure_dof_pattern(pd_kp)
-        self._pd_kv_cfg = _ensure_dof_pattern(pd_kv)
-        self._max_force_cfg = _ensure_dof_pattern(max_force)
-        self._damping_cfg = _ensure_dof_pattern(damping)
-        self._stiffness_cfg = _ensure_dof_pattern(stiffness)
-        self._frictionloss_cfg = _ensure_dof_pattern(frictionloss)
+        self._offset_cfg = ensure_dof_pattern(offset)
+        self._scale_cfg = ensure_dof_pattern(scale)
+        self._clip_cfg = ensure_dof_pattern(clip)
         self._quiet_action_errors = quiet_action_errors
         self._enabled_dof = None
-        self._noise_scale = noise_scale
         self._use_default_offset = use_default_offset
+        self._actuator_manager = actuator_manager
 
-        self._default_dofs_pos: torch.Tensor = None
         self._dofs_pos_buffer: torch.Tensor = None
 
         if use_default_offset and offset != 0.0:
             raise ValueError("Cannot set both use_default_offset and offset")
 
-        if isinstance(joint_names, str):
-            self._joint_name_cfg = [joint_names]
-        elif isinstance(joint_names, list):
-            self._joint_name_cfg = joint_names
-        else:
-            raise TypeError(f"Invalid joint_names type: {type(joint_names)}")
+        # Deprecated actuator parameters
+        deprecated_actuator_args = {
+            key: kwargs[key] for key in deprecated_arg_names if key in kwargs
+        }
+        if len(deprecated_actuator_args) > 0:
+            dep_list = ", ".join(deprecated_actuator_args.keys())
+            if self._actuator_manager is not None:
+                raise ValueError(
+                    f"Cannot set both actuator_manager and deprecated actuator parameters: {dep_list}"
+                )
+            print(
+                f"Actuator arguments are deprecated in the action manager, instead define an ActuatorManager ({dep_list})"
+            )
+            self._actuator_manager = ActuatorManager(
+                env,
+                joint_names=kwargs.get("joint_names", ".*"),
+                default_pos=kwargs.get("default_pos", {".*": 0.0}),
+                kp=kwargs.get("pd_kp", None),
+                kv=kwargs.get("pd_kv", None),
+                max_force=kwargs.get("max_force", None),
+                damping=kwargs.get("damping", None),
+                stiffness=kwargs.get("stiffness", None),
+                frictionloss=kwargs.get("frictionloss", None),
+                default_noise_scale=kwargs.get("noise_scale", 0.0),
+            )
+        if self._actuator_manager is None:
+            raise ValueError("No ActuatorManager provided.")
 
     """
     Properties
     """
+
+    @property
+    def actuators(self) -> ActuatorManager:
+        """
+        Get the actuator manager.
+        """
+        return self._actuator_manager
+
+    @property
+    def num_actions(self) -> int:
+        """
+        Get the number of actions.
+        """
+        return self._actuator_manager.num_dofs
 
     @property
     def action_space(self) -> tuple[float, float]:
@@ -213,29 +200,18 @@ class PositionActionManager(BaseActionManager):
         )
 
     @property
-    def num_actions(self) -> int:
-        """
-        Get the number of actions.
-        """
-        assert (
-            self._enabled_dof is not None
-        ), "PositionalActionManager not initialized. You may need to add <PositionalActionManager>.reset() in your environment's reset method."
-
-        return len(self._enabled_dof)
-
-    @property
     def dofs_idx(self) -> list[int]:
         """
         Get the indices of the DOF that are enabled (via joint_names).
         """
-        return list(self._enabled_dof.values())
+        return self._actuator_manager.dofs_idx
 
     @property
     def default_dofs_pos(self) -> torch.Tensor:
         """
         Return the default DOF positions.
         """
-        return self._default_dofs_pos
+        return self._actuator_manager.default_dofs_pos
 
     """
     DOF Getters
@@ -249,10 +225,7 @@ class PositionActionManager(BaseActionManager):
         Args:
             noise: The maximum amount of random noise to add to the position values returned.
         """
-        pos = self.env.robot.get_dofs_position(self.dofs_idx)
-        if noise > 0.0:
-            pos = self._add_random_noise(pos, noise)
-        return pos
+        return self._actuator_manager.get_dofs_position(noise)
 
     def get_dofs_velocity(self, noise: float = 0.0, clip: tuple[float, float] = None):
         """
@@ -263,12 +236,7 @@ class PositionActionManager(BaseActionManager):
             noise: The maximum amount of random noise to add to the velocity values returned.
             clip: Clip the velocity returned.
         """
-        vel = self.env.robot.get_dofs_velocity(self.dofs_idx)
-        if noise > 0.0:
-            vel = self._add_random_noise(vel, noise)
-        if clip is not None:
-            vel = vel.clamp(**clip)
-        return vel
+        return self._actuator_manager.get_dofs_velocity(noise, clip)
 
     def get_dofs_force(self, noise: float = 0.0, clip_to_max_force: bool = False):
         """
@@ -282,12 +250,7 @@ class PositionActionManager(BaseActionManager):
         Returns:
             The force experienced by the enabled DOFs.
         """
-        force = self.env.robot.get_dofs_force(self.dofs_idx)
-        if noise > 0.0:
-            force = self._add_random_noise(force, noise)
-        if clip_to_max_force and self._force_range is not None:
-            force = force.clamp(self._force_range[0], self._force_range[1])
-        return force
+        return self._actuator_manager.get_dofs_force(noise, clip_to_max_force)
 
     """
     Operations
@@ -298,81 +261,24 @@ class PositionActionManager(BaseActionManager):
         Builds the manager and initialized all the buffers.
         """
 
-        # Find all enabled joints by names/patterns
-        self._enabled_dof = dict()
-        for joint in self.env.robot.joints:
-            if joint.type != gs.JOINT_TYPE.REVOLUTE:
-                continue
-            name = joint.name
-            for pattern in self._joint_name_cfg:
-                if re.match(f"^{pattern}$", name):
-                    self._enabled_dof[name] = joint.dof_start
-                    break
-
-        # Default DOF positions
-        if self._default_pos_cfg is not None:
-            self._default_dofs_pos = self._get_dof_value_tensor(self._default_pos_cfg)
-        else:
-            self._default_dofs_pos = torch.zeros(self.num_actions, device=gs.device)
-        self._default_dofs_pos = self._default_dofs_pos.unsqueeze(0).expand(
-            self.env.num_envs, -1
-        )
-
-        # Get the joint limits
-        lower_limit, upper_limit = self.env.robot.get_dofs_limit(self.dofs_idx)
-
-        # Map config params to the DOF indices
-        self._scale_values = None
-        self._offset_values = None
-        self._kp_values = None
-        self._kv_values = None
-        self._damping_values = None
-        self._stiffness_values = None
-        self._frictionloss_values = None
+        # Define the clip values
+        lower_limit, upper_limit = self._actuator_manager.get_dofs_limits()
         self._clip_values = torch.stack([lower_limit, upper_limit], dim=1)
-        if self._scale_cfg is not None:
-            self._scale_values = self._get_dof_value_tensor(self._scale_cfg)
         if self._clip_cfg is not None:
             self._get_dof_value_tensor(self._clip_cfg, output=self._clip_values)
-        if self._pd_kp_cfg is not None:
-            self._kp_values = self._get_dof_value_tensor(self._pd_kp_cfg)
-        if self._pd_kv_cfg is not None:
-            self._kv_values = self._get_dof_value_tensor(self._pd_kv_cfg)
-        if self._damping_cfg is not None:
-            self._damping_values = self._get_dof_value_tensor(self._damping_cfg)
-        if self._stiffness_cfg is not None:
-            self._stiffness_values = self._get_dof_value_tensor(self._stiffness_cfg)
-        if self._frictionloss_cfg is not None:
-            self._frictionloss_values = self._get_dof_value_tensor(
-                self._frictionloss_cfg
-            )
+
+        # Scale
+        self._scale_values = None
+        if self._scale_cfg is not None:
+            self._scale_values = self._get_dof_value_tensor(self._scale_cfg)
+
+        # Offset
+        self._offset_values = None
         if self._use_default_offset:
-            self._offset_values = self._default_dofs_pos
+            self._offset_values = self._actuator_manager.default_dofs_pos
         else:
             offset = self._offset_cfg if self._offset_cfg is not None else 0.0
             self._offset_values = self._get_dof_value_tensor(offset)
-
-        # Max force
-        # The value can either be a single float or a tuple range
-        self._force_range = None
-        if self._max_force_cfg is not None:
-            max_force = self._get_dof_value_array(self._max_force_cfg)
-
-            # Convert values to upper and lower arrays
-            force_upper = [0.0] * self.num_actions
-            force_lower = [0.0] * self.num_actions
-            for i, value in enumerate(max_force):
-                if isinstance(max_force[0], (list, tuple)):
-                    force_lower[i] = value[0]
-                    force_upper[i] = value[1]
-                else:
-                    force_lower[i] = -value
-                    force_upper[i] = value
-
-            self._force_range = (
-                torch.tensor(force_lower, device=gs.device),
-                torch.tensor(force_upper, device=gs.device),
-            )
 
     def step(self, actions: torch.Tensor) -> torch.Tensor:
         """
@@ -415,67 +321,22 @@ class PositionActionManager(BaseActionManager):
         )
 
         # Set target positions
-        self.env.robot.control_dofs_position(actions, self.dofs_idx)
+        self._actuator_manager.control_dofs_position(actions)
 
         return actions
 
-    def reset(
-        self,
-        envs_idx: list[int] = None,
-    ):
-        """Reset the DOF positions."""
-        if not self.enabled:
-            return
-        if envs_idx is None:
-            envs_idx = torch.arange(self.env.num_envs, device=gs.device)
-
-        # Set DOF values with random scaling
-        if self._kp_values is not None:
-            kp = self._add_random_noise(self._kp_values, self._noise_scale)
-            self.env.robot.set_dofs_kp(kp, self.dofs_idx, envs_idx)
-        if self._kv_values is not None:
-            kv = self._add_random_noise(self._kv_values, self._noise_scale)
-            self.env.robot.set_dofs_kv(kv, self.dofs_idx, envs_idx)
-        if self._damping_values is not None:
-            damping = self._add_random_noise(self._damping_values, self._noise_scale)
-            self.env.robot.set_dofs_damping(damping, self.dofs_idx, envs_idx)
-        if self._stiffness_values is not None:
-            stiffness = self._add_random_noise(
-                self._stiffness_values, self._noise_scale
-            )
-            self.env.robot.set_dofs_stiffness(stiffness, self.dofs_idx, envs_idx)
-        if self._frictionloss_values is not None:
-            frictionloss = self._add_random_noise(
-                self._frictionloss_values, self._noise_scale
-            )
-            self.env.robot.set_dofs_frictionloss(frictionloss, self.dofs_idx, envs_idx)
-        if self._force_range is not None:
-            lower = self._add_random_noise(self._force_range[0], self._noise_scale)
-            upper = self._add_random_noise(self._force_range[1], self._noise_scale)
-            self.env.robot.set_dofs_force_range(lower, upper, self.dofs_idx, envs_idx)
-
-        # Reset DOF positions with random scaling
-        position = self._add_random_noise(
-            self._default_dofs_pos[envs_idx], self._noise_scale
-        )
-        self.env.robot.set_dofs_position(
-            position=position,
-            dofs_idx_local=self.dofs_idx,
-            envs_idx=envs_idx,
-        )
-
     """
-    Implementation
+    Internal methods
     """
 
-    def _get_dof_value_array(
+    def _get_dof_value_tensor(
         self,
-        values: DofValue[T],
+        values: float | dict,
         default_value: T = 0.0,
         output: torch.Tensor | list[Any] | None = None,
-    ) -> torch.Tensor | list[Any]:
+    ) -> torch.Tensor:
         """
-        Given a DofValue dict, loop over the entries, and set the value to the DOF indices (from dofs_idx) that match the pattern.
+         Given a DofValue dict, loop over the entries, and set the value to the DOF indices (from the actuator) that match the pattern.
 
         Args:
             values: The DOF value to convert (for example: `{".*": 50}`).
@@ -485,15 +346,16 @@ class PositionActionManager(BaseActionManager):
             For example, for 4 DOFs: [50, 50, 50, 50]
         """
         is_set = [False] * self.num_actions
+        dof_names = self._actuator_manager.dofs_names
         if output is None:
-            output = [default_value] * self.num_actions
+            output = torch.zeros(
+                self.num_actions, device=gs.device, dtype=gs.tc_float
+            ).fill_(default_value)
         for pattern, value in values.items():
             found = False
-            for i, name in enumerate(self._enabled_dof.keys()):
+            for i, name in enumerate[str](dof_names):
                 if not is_set[i] and re.match(f"^{pattern}$", name):
-                    if isinstance(output, torch.Tensor) and not isinstance(
-                        value, torch.Tensor
-                    ):
+                    if isinstance(value, (list, tuple)):
                         value = torch.tensor(value, device=gs.device)
                     is_set[i] = True
                     output[i] = value
@@ -501,26 +363,3 @@ class PositionActionManager(BaseActionManager):
             if not found:
                 raise RuntimeError(f"Joint DOF '{pattern}' not found.")
         return output
-
-    def _get_dof_value_tensor(
-        self,
-        values: DofValue[T],
-        default_value: T = 0.0,
-        output: torch.Tensor | list[Any] | None = None,
-    ) -> torch.Tensor:
-        """
-        Wrapper for _get_dof_value_array that returns a tensor.
-        """
-        values = self._get_dof_value_array(values, default_value, output)
-        return torch.tensor(values, device=gs.device, dtype=gs.tc_float)
-
-    def _add_random_noise(
-        self, values: torch.Tensor, noise_scale: float = 0.0
-    ) -> torch.Tensor:
-        """
-        Add random noise to the tensor values
-        """
-        if noise_scale == 0.0:
-            return values
-        noise_value = torch.empty_like(values).uniform_(-1, 1) * noise_scale
-        return values + noise_value

--- a/genesis_forge/managers/action/position_action_manager.py
+++ b/genesis_forge/managers/action/position_action_manager.py
@@ -65,7 +65,6 @@ class PositionActionManager(BaseActionManager):
                 )
                 self.action_manager = PositionActionManager(
                     self,
-                    joint_names=".*",
                     scale=0.5,
                     use_default_offset=True,
                     actuator_manager=self.actuator_manager,

--- a/genesis_forge/managers/actuator/__init__.py
+++ b/genesis_forge/managers/actuator/__init__.py
@@ -1,0 +1,7 @@
+from .actuator_manager import ActuatorManager
+from .noisy_value import NoisyValue
+
+__all__ = [
+    "ActuatorManager",
+    "NoisyValue",
+]

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -14,18 +14,28 @@ if TYPE_CHECKING:
 ValueName = Literal[
     "kp",
     "kv",
+    "default_pos",
+    "force_min",
+    "force_max",
     "damping",
     "stiffness",
     "frictionloss",
-    "force_min",
-    "force_max",
-    "default_pos",
+    "armature",
 ]
 
 
 class BufferItem(TypedDict):
     buffer: torch.Tensor
+    """A buffer of values for each DOF index."""
+
     noise: torch.Tensor
+    """The noise for each index of the buffer."""
+
+    has_noise: bool
+    """Does this value have noise associated with it?"""
+
+    has_been_set: bool
+    """Has this value been set to the actuator at least once?"""
 
 
 ValueBuffers = dict[ValueName, BufferItem]
@@ -47,6 +57,7 @@ class ActuatorManager(BaseManager):
         damping: The damping values.
         stiffness: The stiffness values.
         frictionloss: The frictionloss values.
+        armature: The armature values.
         entity_attr: The attribute of the environment to get the robot from.
         default_noise_scale: (deprecated) This noise scale will be applied to all actuator values. Use `NoisyValue` instead.
 
@@ -86,6 +97,7 @@ class ActuatorManager(BaseManager):
         damping: float | NoisyValue | dict = None,
         stiffness: float | NoisyValue | dict = None,
         frictionloss: float | NoisyValue | dict = None,
+        armature: float | NoisyValue | dict = None,
         default_noise_scale: float = 0.0,
         entity_attr: str = "robot",
     ):
@@ -99,17 +111,24 @@ class ActuatorManager(BaseManager):
         self._damping_cfg = ensure_dof_pattern(damping)
         self._stiffness_cfg = ensure_dof_pattern(stiffness)
         self._frictionloss_cfg = ensure_dof_pattern(frictionloss)
+        self._armature_cfg = ensure_dof_pattern(armature)
         self._default_noise_scale = default_noise_scale
 
+        self._batch_dofs_enabled = (
+            env.scene.rigid_options.batch_dofs_info
+            and env.scene.rigid_options.batch_links_info
+        )
+
         self._values: ValueBuffers = {
+            "default_pos": None,
+            "force_min": None,
+            "force_max": None,
             "kp": None,
             "kv": None,
             "damping": None,
             "stiffness": None,
             "frictionloss": None,
-            "force_min": None,
-            "force_max": None,
-            "default_pos": None,
+            "armature": None,
         }
 
         if isinstance(joint_names, str):
@@ -196,7 +215,7 @@ class ActuatorManager(BaseManager):
 
         Args:
             noise: The maximum amount of random noise to add to the force values returned.
-            clip_to_max_force: Clip the force returned to the maximum force defined by the `max_force` parameter.
+            clip_to_max_force: Clip the force returned to the maximum force of the actuators.
 
         Returns:
             The force experienced by the enabled DOFs.
@@ -204,8 +223,9 @@ class ActuatorManager(BaseManager):
         force = self._robot.get_dofs_force(self.dofs_idx)
         if noise > 0.0:
             force = self._add_random_noise(force, noise)
-        if clip_to_max_force and self._force_range is not None:
-            force = force.clamp(self._force_range[0], self._force_range[1])
+        if clip_to_max_force:
+            [lower, upper] = self._robot.get_dofs_force_range(self.dofs_idx)
+            force = force.clamp(lower, upper)
         return force
 
     def get_dofs_limits(self) -> tuple[torch.Tensor, torch.Tensor]:
@@ -269,7 +289,6 @@ class ActuatorManager(BaseManager):
         # Max force
         # The value can either be a single float or a tuple range
         # First normalize them into two dicts: min and max
-        self._force_range = None
         if self._max_force_cfg is not None:
 
             # Normalize the max_force values into a min & max dict
@@ -289,6 +308,18 @@ class ActuatorManager(BaseManager):
             self._fill_value_buffer("force_min", force_min)
             self._fill_value_buffer("force_max", force_max)
 
+        # Armature
+        # If DOF batching is not enabled, print a warning and set the armature values for all environments without noise.
+        if self._armature_cfg is not None:
+            self._fill_value_buffer("armature", self._armature_cfg)
+            if not self._batch_dofs_enabled:
+                armature = self._values["armature"]
+                if torch.any(armature["noise"] != 0.0):
+                    print(
+                        "WARNING: Armature randomization settings are only supported when 'batch_dofs_info' and 'batch_links_info' are True in RigidOptions."
+                    )
+                self._robot.set_dofs_armature(armature["buffer"], self.dofs_idx)
+
         # Other actuator values
         self._fill_value_buffer("kp", self._kp_cfg)
         self._fill_value_buffer("kv", self._kv_cfg)
@@ -303,35 +334,50 @@ class ActuatorManager(BaseManager):
         """Reset the DOF positions."""
         if not self.enabled:
             return
-        if envs_idx is None:
-            envs_idx = torch.arange(self.env.num_envs, device=gs.device)
         dofs_idx = self.dofs_idx
 
-        # Set actuator values
-        if self._values["kp"] is not None:
-            kp = self._get_value_buffer("kp")
+        # Set actuator controller values
+        if self._should_set_value("kp"):
+            kp = self._get_value_buffer("kp", envs_idx)
             self._robot.set_dofs_kp(kp, dofs_idx, envs_idx)
-        if self._values["kv"] is not None:
-            kv = self._get_value_buffer("kv")
-            self._robot.set_dofs_kv(kv, dofs_idx, envs_idx)
-        if self._values["damping"] is not None:
-            damping = self._get_value_buffer("damping")
-            self._robot.set_dofs_damping(damping, dofs_idx, envs_idx)
-        if self._values["stiffness"] is not None:
-            stiffness = self._get_value_buffer("stiffness")
-            self._robot.set_dofs_stiffness(stiffness, dofs_idx, envs_idx)
-        if self._values["frictionloss"] is not None:
-            frictionloss = self._get_value_buffer("frictionloss")
-            self._robot.set_dofs_frictionloss(frictionloss, dofs_idx, envs_idx)
-        if self._force_range is not None:
-            lower = self._get_value_buffer("force_min")
-            upper = self._get_value_buffer("force_max")
-            self._robot.set_dofs_force_range(lower, upper, dofs_idx, envs_idx)
+            self._values["kp"]["has_been_set"] = True
 
-        # Reset DOF positions with random scaling
-        position = self._get_value_buffer("default_pos")
+        if self._should_set_value("kv"):
+            kv = self._get_value_buffer("kv", envs_idx)
+            self._robot.set_dofs_kv(kv, dofs_idx, envs_idx)
+            self._values["kv"]["has_been_set"] = True
+
+        if self._should_set_value("damping"):
+            damping = self._get_value_buffer("damping", envs_idx)
+            self._robot.set_dofs_damping(damping, dofs_idx, envs_idx)
+            self._values["damping"]["has_been_set"] = True
+
+        if self._should_set_value("stiffness"):
+            stiffness = self._get_value_buffer("stiffness", envs_idx)
+            self._robot.set_dofs_stiffness(stiffness, dofs_idx, envs_idx)
+            self._values["stiffness"]["has_been_set"] = True
+
+        if self._should_set_value("frictionloss"):
+            frictionloss = self._get_value_buffer("frictionloss", envs_idx)
+            self._robot.set_dofs_frictionloss(frictionloss, dofs_idx, envs_idx)
+            self._values["frictionloss"]["has_been_set"] = True
+
+        if self._should_set_value("armature") and self._batch_dofs_enabled:
+            armature = self._get_value_buffer("armature", envs_idx)
+            self._robot.set_dofs_armature(armature, dofs_idx, envs_idx)
+            self._values["armature"]["has_been_set"] = True
+
+        if self._should_set_value("force_min") or self._should_set_value("force_max"):
+            force_min = self._get_value_buffer("force_min", envs_idx)
+            force_max = self._get_value_buffer("force_max", envs_idx)
+            self._robot.set_dofs_force_range(force_min, force_max, dofs_idx, envs_idx)
+            self._values["force_min"]["has_been_set"] = True
+            self._values["force_max"]["has_been_set"] = True
+
+        # Reset DOF positions
+        default_position = self._get_value_buffer("default_pos", envs_idx)
         self._robot.set_dofs_position(
-            position=position[envs_idx],
+            position=default_position,
             dofs_idx_local=dofs_idx,
             envs_idx=envs_idx,
         )
@@ -339,6 +385,18 @@ class ActuatorManager(BaseManager):
     """
     Internal methods
     """
+
+    def _should_set_value(self, value_name: ValueName) -> bool:
+        """
+        Check if the actuator control value should.
+        We don't want to set the value if we've already set it and there is no noise associated with it.
+        """
+        cfg = self._values[value_name]
+        if cfg is None:
+            return False
+        if cfg["has_been_set"] and not cfg["has_noise"]:
+            return False
+        return True
 
     def _fill_value_buffer(
         self, value_name: ValueName, config: NoisyValue[float] | None
@@ -355,6 +413,7 @@ class ActuatorManager(BaseManager):
         num_dofs = len(self._dofs)
         is_idx_set = [False] * num_dofs
         dof_names = self._dofs.keys()
+        has_noise = False
 
         # Nothing to be done if the config is None
         if config is None:
@@ -378,13 +437,14 @@ class ActuatorManager(BaseManager):
                     if isinstance(value, NoisyValue):
                         noise[i] = value.noise
                         buffer[i] = value.value
+                        has_noise = True
                     else:
                         buffer[i] = value
             if not found:
                 raise RuntimeError(f"Joint DOF '{pattern}' not found.")
 
         # Expand the default postion buffer to the number of environments
-        if value_name == "default_pos":
+        if value_name == "default_pos" or self._batch_dofs_enabled:
             buffer = buffer.unsqueeze(0).expand(self.env.num_envs, -1)
             noise = noise.unsqueeze(0).expand(self.env.num_envs, -1)
 
@@ -392,15 +452,22 @@ class ActuatorManager(BaseManager):
         self._values[value_name] = {
             "buffer": buffer,
             "noise": noise,
+            "has_noise": has_noise,
+            "has_been_set": False,
         }
 
-    def _get_value_buffer(self, name: ValueName) -> torch.Tensor:
+    def _get_value_buffer(
+        self, name: ValueName, envs_idx: list[int] | None = None
+    ) -> torch.Tensor:
         """
         Get the value buffer tensor, with noise applied
         """
-        values = self._values[name]["buffer"]
+        values = self._values[name]["buffer"].clone()
         noise = self._values[name]["noise"]
-        return values + torch.empty_like(values).uniform_(-1, 1) * noise
+        values += torch.empty_like(values).uniform_(-1, 1) * noise
+        if envs_idx is not None and values.ndim == 2:
+            values = values[envs_idx]
+        return values
 
     def _add_random_noise(
         self, values: torch.Tensor, noise_scale: float = 0.0

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+import re
+import torch
+import genesis as gs
+from typing import Literal, TypedDict, TYPE_CHECKING, Any
+from genesis_forge.genesis_env import GenesisEnv
+from genesis_forge.managers.base import BaseManager
+from genesis_forge.values import ensure_dof_pattern
+from .noisy_value import NoisyValue
+
+if TYPE_CHECKING:
+    from genesis.engine.entities import RigidEntity
+
+ValueName = Literal[
+    "kp",
+    "kv",
+    "damping",
+    "stiffness",
+    "frictionloss",
+    "force_min",
+    "force_max",
+    "default_pos",
+]
+
+
+class BufferItem(TypedDict):
+    buffer: torch.Tensor
+    noise: torch.Tensor
+
+
+ValueBuffers = dict[ValueName, BufferItem]
+
+
+class ActuatorManager(BaseManager):
+    """
+    Configures and manages the actuators of your robot.
+    You can define values for all actuators, or target specific joints by name or name pattern (see example).
+    To add some domain randomization, you can define the values as `NoisyValue` objects, which will apply random noise at each reset.
+
+    Args:
+        env: The environment to manage the DOF actuators for.
+        joint_names: The joint names to manage.
+        default_pos: The default DOF positions. The DOF joints will be set to these positions on reset.
+        kp: The positional gain values.
+        kv: The velocity gains values.
+        max_force: Define the maximum actuator force. Either as a single value or a tuple range.
+        damping: The damping values.
+        stiffness: The stiffness values.
+        frictionloss: The frictionloss values.
+        entity_attr: The attribute of the environment to get the robot from.
+        default_noise_scale: (deprecated) This noise scale will be applied to all actuator values. Use `NoisyValue` instead.
+
+    Example::
+        class MyEnv(ManagedEnvironment):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+                self.actuator_manager = ActuatorManager(
+                    self,
+                    joint_names=".*",
+                    default_pos={
+                        "Leg[1-2]_Hip": -1.0,
+                        "Leg[3-4]_Hip": 1.0,
+                        "Leg[1-4]_Femur": 0.5,
+                        "Leg[1-4]_Tibia": 0.6,
+                    },
+                    kp={
+                        ".*_Hip": NoisyValue(50, 0.02),
+                        "*__Femur": NoisyValue(30, 0.01),
+                        "*__Tibia": NoisyValue(30, 0.01),
+                    },
+                    kv=0.5,
+                    max_force=8.0,
+                )
+
+    """
+
+    def __init__(
+        self,
+        env: GenesisEnv,
+        joint_names: list[str] | str = ".*",
+        default_pos: float | NoisyValue | dict = {".*": 0.0},
+        kp: float | NoisyValue | dict = None,
+        kv: float | NoisyValue | dict = None,
+        max_force: float | NoisyValue | tuple[Any, Any] | dict = None,
+        damping: float | NoisyValue | dict = None,
+        stiffness: float | NoisyValue | dict = None,
+        frictionloss: float | NoisyValue | dict = None,
+        default_noise_scale: float = 0.0,
+        entity_attr: str = "robot",
+    ):
+        super().__init__(env, type="actuator")
+        self._dofs: dict[str, int] = {}
+        self._robot: RigidEntity = getattr(env, entity_attr)
+        self._default_pos_cfg = ensure_dof_pattern(default_pos)
+        self._kp_cfg = ensure_dof_pattern(kp)
+        self._kv_cfg = ensure_dof_pattern(kv)
+        self._max_force_cfg = ensure_dof_pattern(max_force)
+        self._damping_cfg = ensure_dof_pattern(damping)
+        self._stiffness_cfg = ensure_dof_pattern(stiffness)
+        self._frictionloss_cfg = ensure_dof_pattern(frictionloss)
+        self._default_noise_scale = default_noise_scale
+
+        self._values: ValueBuffers = {
+            "kp": None,
+            "kv": None,
+            "damping": None,
+            "stiffness": None,
+            "frictionloss": None,
+            "force_min": None,
+            "force_max": None,
+            "default_pos": None,
+        }
+
+        if isinstance(joint_names, str):
+            self._joint_name_cfg = [joint_names]
+        elif isinstance(joint_names, list):
+            self._joint_name_cfg = joint_names
+
+    """
+    Properties
+    """
+
+    @property
+    def num_dofs(self) -> int:
+        """
+        Get the number of configured DOFs.
+        """
+        return len(self._dofs)
+
+    @property
+    def dofs_idx(self) -> list[int]:
+        """
+        Get the indices of the DOF that are enabled (via joint_names).
+        """
+        return list[int](self._dofs.values())
+
+    @property
+    def dofs_names(self) -> list[str]:
+        """
+        Get the names of the configured DOFs.
+        """
+        return list[str](self._dofs.keys())
+
+    @property
+    def default_dofs_pos(self) -> torch.Tensor:
+        """
+        Return the default DOF positions.
+        """
+        return self._values["default_pos"].get("buffer", None)
+
+    @property
+    def join_names(self) -> list[str]:
+        """
+        Get the names of the joints that are enabled, in the order of the DOF indices.
+        """
+        return list[str](self._dofs.keys())
+
+    """
+    Actuator handlers
+    """
+
+    def get_dofs_position(self, noise: float = 0.0):
+        """
+        Return the current position of the configured DOFs.
+        This is a wrapper for `RigidEntity.get_dofs_position`.
+
+        Args:
+            noise: The maximum amount of random noise to add to the position values returned.
+        """
+        pos = self._robot.get_dofs_position(self.dofs_idx)
+        if noise > 0.0:
+            pos = self._add_random_noise(pos, noise)
+        return pos
+
+    def get_dofs_velocity(self, noise: float = 0.0, clip: tuple[float, float] = None):
+        """
+        Return the current velocity of the configured DOFs.
+        This is a wrapper for `RigidEntity.get_dofs_velocity`.
+
+        Args:
+            noise: The maximum amount of random noise to add to the velocity values returned.
+            clip: Clip the velocity returned.
+        """
+        vel = self._robot.get_dofs_velocity(self.dofs_idx)
+        if noise > 0.0:
+            vel = self._add_random_noise(vel, noise)
+        if clip is not None:
+            vel = vel.clamp(**clip)
+        return vel
+
+    def get_dofs_force(self, noise: float = 0.0, clip_to_max_force: bool = False):
+        """
+        Return the force experienced by the configured DOFs.
+        This is a wrapper for `RigidEntity.get_dofs_force`.
+
+        Args:
+            noise: The maximum amount of random noise to add to the force values returned.
+            clip_to_max_force: Clip the force returned to the maximum force defined by the `max_force` parameter.
+
+        Returns:
+            The force experienced by the enabled DOFs.
+        """
+        force = self._robot.get_dofs_force(self.dofs_idx)
+        if noise > 0.0:
+            force = self._add_random_noise(force, noise)
+        if clip_to_max_force and self._force_range is not None:
+            force = force.clamp(self._force_range[0], self._force_range[1])
+        return force
+
+    def get_dofs_limits(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Return the limits of the configured DOFs.
+        This is a wrapper for `RigidEntity.get_dofs_limit`.
+
+        Returns:
+            A tuple of two tensors, the first is the lower limits and the second is the upper limits.
+            Each tensor is of shape (num_envs, num_dofs).
+        """
+        return self._robot.get_dofs_limit(self.dofs_idx)
+
+    def set_dofs_position(self, position: torch.Tensor):
+        """
+        Set the position of the configured DOFs.
+        This is a wrapper for `RigidEntity.set_dofs_position`.
+
+        Args:
+            position: The position to set the DOFs to. The indices of this tensor should match the configured DOFs
+                      (see: `dofs_names` and `dofs_idx` properties).
+        """
+        self._robot.set_dofs_position(position, self.dofs_idx)
+
+    def control_dofs_position(self, position: torch.Tensor):
+        """
+        Control the position of the configured DOFs.
+        This is a wrapper for `RigidEntity.control_dofs_position`.
+
+        Args:
+            position: The position to set the DOFs to. The indices of this tensor should match the configured DOFs
+                      (see: `dofs_names` and `dofs_idx` properties).
+        """
+        self._robot.control_dofs_position(position, self.dofs_idx)
+
+    """
+    Lifecycle operations
+    """
+
+    def build(self):
+        """
+        Builds the manager and initialized all the buffers.
+        """
+        # Find all configured joints by names/patterns
+        for joint in self._robot.joints:
+            if joint.type != gs.JOINT_TYPE.REVOLUTE:
+                continue
+            name = joint.name
+            for pattern in self._joint_name_cfg:
+                if pattern == name or re.match(f"^{pattern}$", name):
+                    self._dofs[name] = joint.dof_start
+                    break
+
+        # Default DOF positions
+        # If no configuration is provided, use zero positions for all DOFs.
+        if self._default_pos_cfg is not None:
+            self._fill_value_buffer("default_pos", self._default_pos_cfg)
+        else:
+            self._fill_value_buffer("default_pos", {".*": 0.0})
+
+        # Max force
+        # The value can either be a single float or a tuple range
+        # First normalize them into two dicts: min and max
+        self._force_range = None
+        if self._max_force_cfg is not None:
+
+            # Normalize the max_force values into a min & max dict
+            force_min = {}
+            force_max = {}
+            for pattern, value in self._max_force_cfg.items():
+                if isinstance(value, list):
+                    force_min[pattern] = value[0]
+                    force_max[pattern] = value[1]
+                elif isinstance(value, NoisyValue):
+                    force_min[pattern] = NoisyValue(-value.value, value.noise)
+                    force_max[pattern] = value
+                else:
+                    force_min[pattern] = -value
+                    force_max[pattern] = value
+
+            self._fill_value_buffer("force_min", force_min)
+            self._fill_value_buffer("force_max", force_max)
+
+        # Other actuator values
+        self._fill_value_buffer("kp", self._kp_cfg)
+        self._fill_value_buffer("kv", self._kv_cfg)
+        self._fill_value_buffer("damping", self._damping_cfg)
+        self._fill_value_buffer("stiffness", self._stiffness_cfg)
+        self._fill_value_buffer("frictionloss", self._frictionloss_cfg)
+
+    def reset(
+        self,
+        envs_idx: list[int] = None,
+    ):
+        """Reset the DOF positions."""
+        if not self.enabled:
+            return
+        if envs_idx is None:
+            envs_idx = torch.arange(self.env.num_envs, device=gs.device)
+        dofs_idx = self.dofs_idx
+
+        # Set actuator values
+        if self._values["kp"] is not None:
+            kp = self._get_value_buffer("kp")
+            self._robot.set_dofs_kp(kp, dofs_idx, envs_idx)
+        if self._values["kv"] is not None:
+            kv = self._get_value_buffer("kv")
+            self._robot.set_dofs_kv(kv, dofs_idx, envs_idx)
+        if self._values["damping"] is not None:
+            damping = self._get_value_buffer("damping")
+            self._robot.set_dofs_damping(damping, dofs_idx, envs_idx)
+        if self._values["stiffness"] is not None:
+            stiffness = self._get_value_buffer("stiffness")
+            self._robot.set_dofs_stiffness(stiffness, dofs_idx, envs_idx)
+        if self._values["frictionloss"] is not None:
+            frictionloss = self._get_value_buffer("frictionloss")
+            self._robot.set_dofs_frictionloss(frictionloss, dofs_idx, envs_idx)
+        if self._force_range is not None:
+            lower = self._get_value_buffer("force_min")
+            upper = self._get_value_buffer("force_max")
+            self._robot.set_dofs_force_range(lower, upper, dofs_idx, envs_idx)
+
+        # Reset DOF positions with random scaling
+        position = self._get_value_buffer("default_pos")
+        self._robot.set_dofs_position(
+            position=position[envs_idx],
+            dofs_idx_local=dofs_idx,
+            envs_idx=envs_idx,
+        )
+
+    """
+    Internal methods
+    """
+
+    def _fill_value_buffer(
+        self, value_name: ValueName, config: NoisyValue[float] | None
+    ):
+        """
+        Given a ActuatorValue dict, loop over the entries, and set them to the appropriate value buffer DOF indices that match
+        the DOF pattern.
+
+        Args:
+            name: The name of the value buffer to fill
+            values: The DOF value to convert (for example: `{".*": 50}`).
+
+        """
+        num_dofs = len(self._dofs)
+        is_idx_set = [False] * num_dofs
+        dof_names = self._dofs.keys()
+
+        # Nothing to be done if the config is None
+        if config is None:
+            return
+
+        # Initialize the buffers
+        buffer = torch.zeros((num_dofs,), device=gs.device, dtype=gs.tc_float)
+        noise = torch.zeros((num_dofs,), device=gs.device, dtype=gs.tc_float).fill_(
+            self._default_noise_scale
+        )
+
+        for pattern, value in config.items():
+            found = False
+            for i, name in enumerate[str](dof_names):
+                if is_idx_set[i]:
+                    continue
+                if pattern == name or re.match(f"^{pattern}$", name):
+                    found = True
+                    is_idx_set[i] = True
+
+                    if isinstance(value, NoisyValue):
+                        noise[i] = value.noise
+                        buffer[i] = value.value
+                    else:
+                        buffer[i] = value
+            if not found:
+                raise RuntimeError(f"Joint DOF '{pattern}' not found.")
+
+        # Expand the default postion buffer to the number of environments
+        if value_name == "default_pos":
+            buffer = buffer.unsqueeze(0).expand(self.env.num_envs, -1)
+            noise = noise.unsqueeze(0).expand(self.env.num_envs, -1)
+
+        # Expand the buffer to the number of environments
+        self._values[value_name] = {
+            "buffer": buffer,
+            "noise": noise,
+        }
+
+    def _get_value_buffer(self, name: ValueName) -> torch.Tensor:
+        """
+        Get the value buffer tensor, with noise applied
+        """
+        values = self._values[name]["buffer"]
+        noise = self._values[name]["noise"]
+        return values + torch.empty_like(values).uniform_(-1, 1) * noise
+
+    def _add_random_noise(
+        self, values: torch.Tensor, noise_scale: float = 0.0
+    ) -> torch.Tensor:
+        """
+        Add random noise to the tensor values
+        """
+        if noise_scale == 0.0:
+            return values
+        noise_value = torch.empty_like(values).uniform_(-1, 1) * noise_scale
+        return values + noise_value

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -167,7 +167,7 @@ class ActuatorManager(BaseManager):
         """
         Return the default DOF positions.
         """
-        return self._values["default_pos"].get("buffer", None)
+        return self._values.get("default_pos", {}).get("buffer", None)
 
     @property
     def join_names(self) -> list[str]:

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -62,6 +62,7 @@ class ActuatorManager(BaseManager):
         default_noise_scale: (deprecated) This noise scale will be applied to all actuator values. Use `NoisyValue` instead.
 
     Example::
+
         class MyEnv(ManagedEnvironment):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)

--- a/genesis_forge/managers/actuator/noisy_value.py
+++ b/genesis_forge/managers/actuator/noisy_value.py
@@ -1,6 +1,17 @@
 class NoisyValue:
     """
-    Defines a value with some noise settings.
+    Defines a base value and the noise which will be added to it.
+    This class is merely a configuration container, and does not apply the noise directly.
+
+    Args:
+        value: The value to configure the manager with.
+        noise: The noise (+/-) to apply to the value as noise.
+
+    Example::
+
+        value = NoisyValue(10.0, noise=2.0)
+        # The base value is 10.0, and the noise will be +/- 2.0
+        # So the final value will be between 8.0 and 12.0
     """
 
     def __init__(
@@ -8,13 +19,5 @@ class NoisyValue:
         value: float,
         noise: float = 0.0,
     ):
-        """
-        Args:
-            value: The value to configure the manager with.
-            noise: The noise (+/-) to apply to the value as noise.
-
-        Example:
-            >>> value = NoisyValue(10.0, noise=0.01)
-        """
         self.value = value
         self.noise = noise

--- a/genesis_forge/managers/actuator/noisy_value.py
+++ b/genesis_forge/managers/actuator/noisy_value.py
@@ -5,16 +5,16 @@ class NoisyValue:
 
     def __init__(
         self,
-        value: float | None = None,
-        noise: float | None = None,
+        value: float,
+        noise: float = 0.0,
     ):
         """
         Args:
             value: The value to configure the manager with.
-            noise: The noise scale (+/-) to apply to the value as noise.
+            noise: The noise (+/-) to apply to the value as noise.
 
         Example:
             >>> value = NoisyValue(10.0, noise=0.01)
         """
         self.value = value
-        self.noise = 0
+        self.noise = noise

--- a/genesis_forge/managers/actuator/noisy_value.py
+++ b/genesis_forge/managers/actuator/noisy_value.py
@@ -1,0 +1,20 @@
+class NoisyValue:
+    """
+    Defines a value with some noise settings.
+    """
+
+    def __init__(
+        self,
+        value: float | None = None,
+        noise: float | None = None,
+    ):
+        """
+        Args:
+            value: The value to configure the manager with.
+            noise: The noise scale (+/-) to apply to the value as noise.
+
+        Example:
+            >>> value = NoisyValue(10.0, noise=0.01)
+        """
+        self.value = value
+        self.noise = 0

--- a/genesis_forge/managers/base.py
+++ b/genesis_forge/managers/base.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 ManagerType = Literal[
     "action",
+    "actuator",
     "reward",
     "termination",
     "contact",

--- a/genesis_forge/managers/command/command_manager.py
+++ b/genesis_forge/managers/command/command_manager.py
@@ -314,9 +314,9 @@ class CommandManager(BaseManager):
             ranges = [self._range]
 
         # Resample the command
-        buffer = torch.empty(len(env_ids), device=gs.device)
         for i in range(self._command.shape[1]):
-            self._command[env_ids, i] = buffer.uniform_(*ranges[i])
+            buffer = torch.empty(len(env_ids), device=gs.device).uniform_(*ranges[i])
+            self._command[env_ids, i] = buffer
 
     """
     Implementation

--- a/genesis_forge/managers/command/command_manager.py
+++ b/genesis_forge/managers/command/command_manager.py
@@ -156,8 +156,13 @@ class CommandManager(BaseManager):
             self._command[:, self._range_idx[range_key]] = value
         else:
             self._command[envs_idx, self._range_idx[range_key]] = value
-    
-    def increment_range(self, range_key: str, increment: float | tuple[float, float], limit: float | tuple[float, float] = None):
+
+    def increment_range(
+        self,
+        range_key: str,
+        increment: float | tuple[float, float],
+        limit: float | tuple[float, float] = None,
+    ):
         """
         Increment a command range target values by the given amount, with an optional limit.
 
@@ -171,7 +176,7 @@ class CommandManager(BaseManager):
 
             # Increment the range min by -0.25 and max by 1.0
             command_manager.increment_range("height", (-0.25, 1.0))
-            
+
             # Increment the range by (-0.25, 1.0) and keep min above -0.5 and max below 2.0
             command_manager.increment_range("height", (-0.25, 1.0), (-0.5, 2.0))
 
@@ -186,10 +191,10 @@ class CommandManager(BaseManager):
         # Get the range to increment, and ensure it is a list, not a tuple (tuples are immutable)
         if not isinstance(self.range, dict):
             raise ValueError("Cannot increment a non-dict range item")
-        range_item = self.range.get(range_key, None) 
+        range_item = self._range.get(range_key, None)
         if range_item is None:
             raise ValueError(f"Range item {range_key} not found")
-        range_item = list(range_item)
+        range_item = list[float](range_item)  # Ensure it's a list, not a tuple
 
         # Expand single increment/limit values to tuples
         if not isinstance(increment, (list, tuple)):
@@ -206,7 +211,7 @@ class CommandManager(BaseManager):
                 else:
                     value = max(value, limit[i])
             range_item[i] = value
-        self.range[range_key] = range_item
+        self._range[range_key] = range_item
 
     def get_command_idx(self, key: str) -> int:
         """

--- a/genesis_forge/managers/command/command_manager.py
+++ b/genesis_forge/managers/command/command_manager.py
@@ -183,11 +183,13 @@ class CommandManager(BaseManager):
             limit: Do not set the values beyond this limit range.
                    This is a tuple of `(min_limit, max_limit)`.
         """
+        # Get the range to increment, and ensure it is a list, not a tuple (tuples are immutable)
         if not isinstance(self.range, dict):
             raise ValueError("Cannot increment a non-dict range item")
         range_item = self.range.get(range_key, None) 
         if range_item is None:
             raise ValueError(f"Range item {range_key} not found")
+        range_item = list(range_item)
 
         # Expand single increment/limit values to tuples
         if not isinstance(increment, (list, tuple)):

--- a/genesis_forge/managers/command/velocity_command.py
+++ b/genesis_forge/managers/command/velocity_command.py
@@ -148,10 +148,6 @@ class VelocityCommandManager(CommandManager):
         )
 
     """
-    Properties
-    """
-
-    """
     Operations
     """
 

--- a/genesis_forge/managers/command/velocity_command.py
+++ b/genesis_forge/managers/command/velocity_command.py
@@ -142,14 +142,26 @@ class VelocityCommandManager(CommandManager):
         self.standing_probability = standing_probability
         self.debug_visualizer = debug_visualizer
         self.visualizer_cfg = {**DEFAULT_VISUALIZER_CONFIG, **debug_visualizer_cfg}
+        self.debug_envs_idx = None
 
         self._is_standing_env = torch.zeros(
             env.num_envs, dtype=torch.bool, device=gs.device
         )
 
     """
-    Operations
+    Lifecycle Operations
     """
+
+    def build(self):
+        """Build the velocity command manager"""
+        super().build()
+
+        # If debug envs_idx is not set, attempt to use the vis_options rendered_envs_idx
+        self.debug_envs_idx = self.visualizer_cfg.get("envs_idx", None)
+        if self.debug_envs_idx is None and self.env.scene.vis_options is not None:
+            self.debug_envs_idx = self.env.scene.vis_options.rendered_envs_idx
+        if self.debug_envs_idx is None:
+            self.debug_envs_idx = list[int](range(self.env.num_envs))
 
     def step(self):
         """Render the command arrows"""
@@ -252,12 +264,7 @@ class VelocityCommandManager(CommandManager):
         actual_vec[:, 2] = 0.0
         actual_vec[:, :] *= scale_factor
 
-        debug_envs = (
-            self.visualizer_cfg["envs_idx"]
-            if self.visualizer_cfg["envs_idx"] is not None
-            else range(self.env.num_envs)
-        )
-        for i in debug_envs:
+        for i in self.debug_envs_idx:
             # Target arrow (robot-relative command transformed to world coordinates for visualization)
             self._draw_arrow(
                 pos=arrow_pos[i],

--- a/genesis_forge/managers/command/velocity_command.py
+++ b/genesis_forge/managers/command/velocity_command.py
@@ -152,6 +152,21 @@ class VelocityCommandManager(CommandManager):
     Lifecycle Operations
     """
 
+    def resample_command(self, env_ids: list[int]):
+        """
+        Overwrites commands for environments that should be standing still.
+        """
+        super().resample_command(env_ids)
+        if not self.enabled:
+            return
+
+        num = torch.empty(len(env_ids), device=gs.device)
+        self._is_standing_env[env_ids] = (
+            num.uniform_(0.0, 1.0) <= self.standing_probability
+        )
+        standing_envs_idx = self._is_standing_env.nonzero(as_tuple=False).flatten()
+        self._command[standing_envs_idx, :] = 0.0
+
     def build(self):
         """Build the velocity command manager"""
         super().build()
@@ -196,23 +211,8 @@ class VelocityCommandManager(CommandManager):
         )
 
     """
-    Implementation
+    Internal Implementation
     """
-
-    def _resample_command(self, env_ids: list[int]):
-        """
-        Overwrites commands for environments that should be standing still.
-        """
-        super().resample_command(env_ids)
-        if not self.enabled:
-            return
-
-        num = torch.empty(len(env_ids), device=gs.device)
-        self._is_standing_env[env_ids] = (
-            num.uniform_(0.0, 1.0) <= self.standing_probability
-        )
-        standing_envs_idx = self._is_standing_env.nonzero(as_tuple=False).flatten()
-        self._command[standing_envs_idx, :] = 0.0
 
     def _render_arrows(self):
         """

--- a/genesis_forge/mdp/observations.py
+++ b/genesis_forge/mdp/observations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import torch
 from genesis_forge.genesis_env import GenesisEnv
 from genesis_forge.managers import (
+    ActuatorManager,
     PositionActionManager,
     EntityManager,
     ContactManager,
@@ -87,23 +88,28 @@ DOF/Join observations
 
 def entity_dofs_position(
     env: GenesisEnv,
-    action_manager: PositionActionManager = None,
+    actuator_manager: ActuatorManager = None,
     entity_attr: str = "robot",
     dofs_idx: list[int] = None,
+    action_manager: PositionActionManager = None,
 ) -> torch.Tensor:
     """
     The position of the entity's DOFs.
 
     Args:
         env: The Genesis environment containing the entity
-        action_manager: The action manager for the robot/entity.
-                        This is slightly more performant than using the `entity_attr` parameter.
+        actuator_manager: The actuator manager for the robot/entity.
+                          This bypasses the need for dofs_idx and entity_attr parameters.
         entity_attr: The attribute name of the entity in the environment. This isn't necessary if `action_manager` is provided.
         dofs_idx: The indices of the DOFs to get the position of. This isn't necessary if `action_manager` is provided.
+        action_manager: (deprecated) The action manager for the robot/entity.
+                        This bypasses the need for dofs_idx and entity_attr parameters.
 
     Returns:
         torch.Tensor: The position of the entity's DOFs.
     """
+    if actuator_manager is not None:
+        return actuator_manager.get_dofs_position()
     if action_manager is not None:
         return action_manager.get_dofs_position()
     entity: RigidEntity = getattr(env, entity_attr)
@@ -137,26 +143,30 @@ def entity_dofs_velocity(
 
 def entity_dofs_force(
     env: GenesisEnv,
-    action_manager: PositionActionManager = None,
+    actuator_manager: ActuatorManager = None,
     entity_attr: str = "robot",
     dofs_idx: list[int] = None,
     clip_to_max_force: bool = False,
+    action_manager: PositionActionManager = None,
 ) -> torch.Tensor:
     """
     The DOF's force being experienced.
 
     Args:
         env: The Genesis environment containing the entity
-        action_manager: The action manager for the robot/entity.
-                        This is slightly more performant than using the `entity_attr` parameter.
+        actuator_manager: The actuator manager for the robot/entity.
+                          This bypasses the need for dofs_idx and entity_attr parameters.
         entity_attr: The attribute name of the entity in the environment. This isn't necessary if `action_manager` is provided.
         dofs_idx: The indices of the DOFs to get the force of. This isn't necessary if `action_manager` is provided.
         clip_to_max_force: Clip the force to the maximum force defined in the `action_manager`.
+        action_manager: (deprecated) The action manager for the robot/entity.
 
     Returns:
         torch.Tensor: The force of the entity's DOFs.
     """
-    if action_manager is not None:
+    if actuator_manager is not None:
+        return actuator_manager.get_dofs_force(clip_to_max_force=clip_to_max_force)
+    elif action_manager is not None:
         return action_manager.get_dofs_force(clip_to_max_force=clip_to_max_force)
     entity: RigidEntity = getattr(env, entity_attr)
     return entity.get_dofs_force(dofs_idx)

--- a/genesis_forge/mdp/reset.py
+++ b/genesis_forge/mdp/reset.py
@@ -268,6 +268,10 @@ class randomize_link_mass_shift(ResetMdpFnClass):
                 self._mass_shift_buffer = torch.zeros(
                     (self.env.num_envs, len(self._links_idx_local)), device=gs.device
                 )
+            else:
+                raise ValueError(
+                    f"No links found with name/pattern '{self._link_name}'"
+                )
 
     def __call__(
         self,
@@ -282,7 +286,7 @@ class randomize_link_mass_shift(ResetMdpFnClass):
 
         # Set mass on entity
         self._entity.set_mass_shift(
-            self._mass_shift_buffer,
+            self._mass_shift_buffer[envs_idx],
             links_idx_local=self._links_idx_local,
             envs_idx=envs_idx,
         )

--- a/genesis_forge/mdp/reset.py
+++ b/genesis_forge/mdp/reset.py
@@ -233,14 +233,15 @@ class randomize_terrain_position(ResetMdpFnClass):
 class randomize_link_mass_shift(ResetMdpFnClass):
     """
     Randomly add/subtract mass to one or more links of the entity.
-    This picks a random value from `add_mass_range` and passes it to `set_mass_shift` for each environment.
-    This means that on subsequent calls, the mass can continue to either decrease or increase.
+    This picks a random value from `mass_range` and passes it to `set_mass_shift` for each environment.
+
+    See: https://genesis-world.readthedocs.io/en/latest/api_reference/entity/rigid_entity/rigid_entity.html#genesis.engine.entities.rigid_entity.rigid_entity.RigidEntity.set_mass_shift
 
     Args:
         env: The environment
         entity: The entity to set the rotation of.
-        link_name: The name, or regex pattern, of the link(s) to set the inertial mass for.
-        add_mass_range: The range of the mass that can be added or subtracted each reset.
+        link_name: The name, or regex pattern, of the link(s) to set the mass for.
+        mass_range: The range of the mass that will be added or subtracted from the link(s) on each reset.
     """
 
     def __init__(
@@ -248,10 +249,9 @@ class randomize_link_mass_shift(ResetMdpFnClass):
         _env: GenesisEnv,
         entity: RigidEntity,
         link_name: str,
-        add_mass_range: tuple[float, float] = (-0.2, 0.2),
+        mass_range: tuple[float, float],
     ):
         self.env = _env
-        self.add_mass_range = add_mass_range
         self._entity = entity
         self._link_name = link_name
         self._links_idx_local = []
@@ -279,10 +279,10 @@ class randomize_link_mass_shift(ResetMdpFnClass):
         entity: RigidEntity,
         envs_idx: list[int],
         link_name: str,
-        add_mass_range: tuple[float, float] = (-0.2, 0.2),
+        mass_range: tuple[float, float],
     ):
         # Randomize mass
-        self._mass_shift_buffer[envs_idx, :].uniform_(*self.add_mass_range)
+        self._mass_shift_buffer[envs_idx, :].uniform_(*mass_range)
 
         # Set mass on entity
         self._entity.set_mass_shift(

--- a/genesis_forge/values/__init__.py
+++ b/genesis_forge/values/__init__.py
@@ -1,0 +1,5 @@
+from .dof_value import ensure_dof_pattern
+
+__all__ = [
+    "ensure_dof_pattern",
+]

--- a/genesis_forge/values/dof_value.py
+++ b/genesis_forge/values/dof_value.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import Any
+
+
+def ensure_dof_pattern(value: dict[str, Any] | Any) -> dict[str, Any] | None:
+    """
+    Ensures the value is a dictionary in the form: {<joint name or regex>: <value>}.
+
+    Example:
+        >>> ensure_dof_pattern(50)
+        {".*": 50}
+        >>> ensure_dof_pattern({".*": 50})
+        {".*": 50}
+        >>> ensure_dof_pattern({"knee_joint": 50})
+        {"knee_joint": 50}
+
+    Args:
+        value: The value to convert.
+
+    Returns:
+        A dictionary of DOF name pattern to value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    return {".*": value}

--- a/genesis_forge/wrappers/rsl_rl.py
+++ b/genesis_forge/wrappers/rsl_rl.py
@@ -1,6 +1,6 @@
 import torch
 from tensordict import TensorDict
-from typing import Any
+from typing import Any, Union, Optional
 import genesis as gs
 from importlib import metadata
 
@@ -86,7 +86,9 @@ class RslRlWrapper(Wrapper):
         extras = self._add_observations_to_extras(obs, self.env.extras)
         return obs, extras
 
-    def _add_observations_to_extras(self, obs: torch.Tensor, extras: dict | None):
+    def _add_observations_to_extras(
+        self, obs: torch.Tensor, extras: Optional[dict[str, Any]]
+    ):
         """
         Add the observations to the extras dictionary.
         """
@@ -99,8 +101,8 @@ class RslRlWrapper(Wrapper):
         return extras
 
     def _format_obs_group(
-        self, obs: torch.Tensor, extras: dict | None
-    ) -> torch.Tensor | TensorDict:
+        self, obs: torch.Tensor, extras: Optional[dict[str, Any]]
+    ) -> Union[torch.Tensor, TensorDict]:
         """
         If we're using rsl_rl 3.0+, put the observations into a TensorDict
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
   "genesis-world>=0.3.4",
   "gymnasium",
+  "deprecated",
   "hidapi",
   "skrl[torch]",
   "torch",


### PR DESCRIPTION
It never felt right combining actuator configuration/control with the actions manager. I also want to add noise configuration at the actuator config item level, i.e. kp specific noise, damping specific noise, etc.

This PR pulls the actuator settings out of the action controller and puts them into a dedicated ActuatorManager

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `ActuatorManager` (with `NoisyValue`) to own DOF config/control, refactors action/MDP APIs, updates lifecycle/docs/examples, and adds a domain-randomization example.
> 
> - **Managers**:
>   - **`ActuatorManager` (new)**: Centralizes DOF actuator config/control (`kp/kv`, `max_force`, damping, stiffness, frictionloss, armature, default positions); noise via `NoisyValue`; integrated into `ManagedEnvironment` build/reset.
>   - **`PositionActionManager`**: Now requires `actuator_manager`; actuator args deprecated; clipping/offset/scale use actuator limits/defaults; getters marked deprecated (delegate to actuator manager).
>   - **`PositionWithinLimitsActionManager`**: Updated to use `ActuatorManager` for limits/control.
> - **MDP API**:
>   - Observations/Rewards accept `actuator_manager` (fallback to deprecated `action_manager`) for DOF state and defaults.
>   - Reset: `randomize_link_mass_shift` param renamed to `mass_range` and behavior clarified.
> - **Command/Vis/Contact**:
>   - `CommandManager.increment_range` fixes mutation; resampling simplified.
>   - `VelocityCommandManager` and `ContactManager` set debug env indices from scene/override; standing env handling moved to `resample_command`.
> - **Utilities**:
>   - New `values.ensure_dof_pattern`; minor typing/cleanup in `RslRlWrapper`.
> - **Docs**:
>   - New API pages for `actuator` and `NoisyValue`; guides updated to show actuator+action flow and latency; managers index includes actuator.
> - **Examples**:
>   - All examples migrated to `ActuatorManager` + `PositionActionManager` wiring.
>   - New `examples/domain_randomization` (env/train/eval) demonstrating noisy actuators and sensor/mass randomization.
> - **Deps**:
>   - Add `deprecated` package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10246dfb54c8c457f67020b610a0f6d978616971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->