### PR TITLE
Performance tuning

### DIFF
--- a/genesis_forge/genesis_env.py
+++ b/genesis_forge/genesis_env.py
@@ -198,11 +198,11 @@ class GenesisEnv:
         self.episode_length += 1
 
         if self._actions is None:
-            self._actions = actions.detach().clone()
-            self._last_actions = torch.zeros_like(actions, device=gs.device)
-        else:
-            self._last_actions[:] = self._actions[:]
-            self._actions[:] = actions[:]
+            self._actions = torch.empty_like(actions, device=gs.device)
+            self._last_actions = torch.empty_like(actions, device=gs.device)
+
+        self._last_actions[:] = self._actions[:]
+        self._actions[:] = actions[:]
 
         return None, None, None, None, self._extras
 
@@ -230,7 +230,7 @@ class GenesisEnv:
                 device=gs.device,
                 dtype=gs.tc_float,
             )
-            self._last_actions = torch.zeros_like(self.actions, device=gs.device)
+            self._last_actions = torch.zeros_like(self._actions, device=gs.device)
 
         # Actions
         if envs_idx.numel() > 0:

--- a/genesis_forge/genesis_env.py
+++ b/genesis_forge/genesis_env.py
@@ -198,8 +198,8 @@ class GenesisEnv:
         self.episode_length += 1
 
         if self._actions is None:
-            self._actions = torch.empty_like(actions, device=gs.device)
-            self._last_actions = torch.empty_like(actions, device=gs.device)
+            self._actions = torch.zeros_like(actions, device=gs.device)
+            self._last_actions = torch.zeros_like(actions, device=gs.device)
 
         self._last_actions[:] = self._actions[:]
         self._actions[:] = actions[:]

--- a/genesis_forge/managed_env.py
+++ b/genesis_forge/managed_env.py
@@ -152,6 +152,7 @@ class ManagedEnvironment(GenesisEnv):
         self._truncated_buf = torch.zeros(
             (self.num_envs,), device=gs.device, dtype=gs.tc_bool
         )
+        self._observations_buf = TensorDict({}, device=gs.device)
 
     """
     Properties
@@ -289,7 +290,6 @@ class ManagedEnvironment(GenesisEnv):
             Batch of (observations, rewards, terminations, truncations, extras)
         """
         super().step(actions)
-        self.extras["observations"] = TensorDict({}, device=gs.device)
 
         # Execute the actions and a simulation step
         if self.managers["action"] is not None:
@@ -383,23 +383,21 @@ class ManagedEnvironment(GenesisEnv):
         If you use the ObservationManager, this will be handled automatically.
         Otherwise, override this method to return the observations.
         """
+        self.extras["observations"] = self._observations_buf
+        self._observations_buf.clear()
+
         if len(self.managers["observation"]) > 0:
-            # We already have observations for this step
-            if (
-                "observations" in self.extras
-                and "policy" in self.extras["observations"]
-            ):
+            # We already have policy observations for this step
+            if "policy" in self.extras["observations"]:
                 return self.extras["observations"]["policy"]
-            if "observations" not in self.extras:
-                self.extras["observations"] = TensorDict({}, device=gs.device)
 
             # Get observations
             policy_obs = None
             for obs_manager in self.managers["observation"]:
                 obs = obs_manager.get_observations()
                 self.extras["observations"][obs_manager.name] = obs
+
                 if obs_manager.name == "policy":
                     policy_obs = obs
             return policy_obs
-
         return super().get_observations()

--- a/genesis_forge/managed_env.py
+++ b/genesis_forge/managed_env.py
@@ -386,18 +386,15 @@ class ManagedEnvironment(GenesisEnv):
         self.extras["observations"] = self._observations_buf
         self._observations_buf.clear()
 
+        # Get observations
         if len(self.managers["observation"]) > 0:
-            # We already have policy observations for this step
-            if "policy" in self.extras["observations"]:
-                return self.extras["observations"]["policy"]
-
-            # Get observations
             policy_obs = None
             for obs_manager in self.managers["observation"]:
                 obs = obs_manager.get_observations()
                 self.extras["observations"][obs_manager.name] = obs
-
                 if obs_manager.name == "policy":
                     policy_obs = obs
             return policy_obs
+
+        # Otherwise, call super
         return super().get_observations()

--- a/genesis_forge/managers/action/base.py
+++ b/genesis_forge/managers/action/base.py
@@ -76,9 +76,8 @@ class BaseActionManager(BaseManager):
         # Copy the actions into the manager buffer
         self._raw_actions = actions
         if self._actions is None:
-            self._actions = self._raw_actions.clone()
-        else:
-            self._actions[:] = self._raw_actions[:]
+            self._actions = torch.empty_like(actions, device=gs.device)
+        self._actions[:] = self._raw_actions[:]
         return self._actions
 
     def reset(self, envs_idx: list[int] | None):

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -29,7 +29,13 @@ class BufferItem(TypedDict):
     """A buffer of values for each DOF index."""
 
     noise: torch.Tensor
-    """The noise for each index of the buffer."""
+    """The noise scale for each index of the buffer."""
+
+    noise_buffer: torch.Tensor
+    """A pre-allocated buffer that will be filled with random noise values at each reset."""
+
+    output_buffer: torch.Tensor
+    """A pre-allocated buffer that will be filled with the values at each step."""
 
     has_noise: bool
     """Does this value have noise associated with it?"""
@@ -421,10 +427,12 @@ class ActuatorManager(BaseManager):
             return
 
         # Initialize the buffers
-        buffer = torch.zeros((num_dofs,), device=gs.device, dtype=gs.tc_float)
+        value_buffer = torch.zeros((num_dofs,), device=gs.device, dtype=gs.tc_float)
         noise = torch.zeros((num_dofs,), device=gs.device, dtype=gs.tc_float).fill_(
             self._default_noise_scale
         )
+        noise_buffer = torch.zeros_like(value_buffer, device=gs.device)
+        output_buffer = torch.zeros_like(value_buffer, device=gs.device)
 
         for pattern, value in config.items():
             found = False
@@ -437,22 +445,24 @@ class ActuatorManager(BaseManager):
 
                     if isinstance(value, NoisyValue):
                         noise[i] = value.noise
-                        buffer[i] = value.value
+                        value_buffer[i] = value.value
                         has_noise = True
                     else:
-                        buffer[i] = value
+                        value_buffer[i] = value
             if not found:
                 raise RuntimeError(f"Joint DOF '{pattern}' not found.")
 
         # Expand the default postion buffer to the number of environments
         if value_name == "default_pos" or self._batch_dofs_enabled:
-            buffer = buffer.unsqueeze(0).expand(self.env.num_envs, -1)
+            value_buffer = value_buffer.unsqueeze(0).expand(self.env.num_envs, -1)
             noise = noise.unsqueeze(0).expand(self.env.num_envs, -1)
 
         # Expand the buffer to the number of environments
         self._values[value_name] = {
-            "buffer": buffer,
+            "buffer": value_buffer,
             "noise": noise,
+            "noise_buffer": noise_buffer,
+            "output_buffer": output_buffer,
             "has_noise": has_noise,
             "has_been_set": False,
         }
@@ -463,12 +473,15 @@ class ActuatorManager(BaseManager):
         """
         Get the value buffer tensor, with noise applied
         """
-        values = self._values[name]["buffer"].clone()
+        output = self._values[name]["output_buffer"]
         noise = self._values[name]["noise"]
-        values += torch.empty_like(values).uniform_(-1, 1) * noise
-        if envs_idx is not None and values.ndim == 2:
-            values = values[envs_idx]
-        return values
+        noise_buffer = self._values[name]["noise_buffer"]
+
+        output[:] = self._values[name]["buffer"]
+        output += noise_buffer.uniform_(-1, 1) * noise
+        if envs_idx is not None and output.ndim == 2:
+            output = output[envs_idx]
+        return output
 
     def _add_random_noise(
         self, values: torch.Tensor, noise_scale: float = 0.0

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -454,8 +454,10 @@ class ActuatorManager(BaseManager):
 
         # Expand the default postion buffer to the number of environments
         if value_name == "default_pos" or self._batch_dofs_enabled:
-            value_buffer = value_buffer.unsqueeze(0).expand(self.env.num_envs, -1)
-            noise = noise.unsqueeze(0).expand(self.env.num_envs, -1)
+            value_buffer = value_buffer.unsqueeze(0).repeat(self.env.num_envs, 1)
+            noise = noise.unsqueeze(0).repeat(self.env.num_envs, 1)
+            noise_buffer = noise_buffer.unsqueeze(0).repeat(self.env.num_envs, 1)
+            output_buffer = output_buffer.unsqueeze(0).repeat(self.env.num_envs, 1)
 
         # Expand the buffer to the number of environments
         self._values[value_name] = {

--- a/genesis_forge/managers/command/velocity_command.py
+++ b/genesis_forge/managers/command/velocity_command.py
@@ -1,3 +1,4 @@
+import math
 from typing import Tuple, TypedDict
 
 import os
@@ -41,14 +42,18 @@ class VelocityDebugVisualizerConfig(TypedDict):
     actual_color: Tuple[float, float, float, float]
     """The color of the actual robot velocity arrow"""
 
+    fps: int
+    """The FPS of the debug visualization. Lower FPS means fewer frames are rendered, saving GPU memory."""
+
 
 DEFAULT_VISUALIZER_CONFIG: VelocityDebugVisualizerConfig = {
     "envs_idx": None,
-    "arrow_offset": 0.03,
+    "arrow_offset": 0.12,
     "arrow_radius": 0.02,
     "arrow_max_length": 0.15,
     "commanded_color": (0.0, 0.5, 0.0, 1.0),
     "actual_color": (0.0, 0.0, 0.5, 1.0),
+    "fps": 30,
 }
 
 
@@ -160,16 +165,29 @@ class VelocityCommandManager(CommandManager):
         if not self.enabled:
             return
 
-        num = torch.empty(len(env_ids), device=gs.device)
-        self._is_standing_env[env_ids] = (
-            num.uniform_(0.0, 1.0) <= self.standing_probability
-        )
+        # Set standing environments
+        rand_buffer = torch.empty(len(env_ids), device=gs.device).uniform_(0.0, 1.0)
+        self._is_standing_env[env_ids] = rand_buffer <= self.standing_probability
         standing_envs_idx = self._is_standing_env.nonzero(as_tuple=False).flatten()
         self._command[standing_envs_idx, :] = 0.0
 
     def build(self):
         """Build the velocity command manager"""
         super().build()
+        self.build_debug()
+
+    def build_debug(self):
+        """Build the debug components of the velocity command manager"""
+        if not self.debug_visualizer or self.visualizer_cfg is None:
+            return
+
+        # Pre-allocate buffers
+        self._arrow_pos_buffer = torch.zeros(self.env.num_envs, 3, device=gs.device)
+        self._actual_vec_buffer = torch.zeros(self.env.num_envs, 3, device=gs.device)
+        self._vec_3d_buffer = torch.zeros(self.env.num_envs, 3, device=gs.device)
+        self._scene_env_offset = torch.from_numpy(self.env.scene.envs_offset).to(
+            gs.device
+        )
 
         # If debug envs_idx is not set, attempt to use the vis_options rendered_envs_idx
         self.debug_envs_idx = self.visualizer_cfg.get("envs_idx", None)
@@ -177,6 +195,18 @@ class VelocityCommandManager(CommandManager):
             self.debug_envs_idx = self.env.scene.vis_options.rendered_envs_idx
         if self.debug_envs_idx is None:
             self.debug_envs_idx = list[int](range(self.env.num_envs))
+
+        # Calculate the number of steps per debug render
+        fps = self.visualizer_cfg.get("fps", 30)
+        self._steps_per_debug_render = math.ceil(1.0 / fps / self.env.dt)
+
+        # Arrow scale factor
+        # Scales the arrow size based on the maximum target velocity range
+        self._arrow_scale_factor = self.visualizer_cfg["arrow_max_length"] / max(
+            *self._range["lin_vel_x"],
+            *self._range["lin_vel_y"],
+            *self._range["ang_vel_z"],
+        )
 
     def step(self):
         """Render the command arrows"""
@@ -221,7 +251,12 @@ class VelocityCommandManager(CommandManager):
         The commanded velocity arrow (green) shows the robot-relative velocity command
         transformed to world coordinates for visualization. The blue arrow is the robot's actual velocity.
         """
-        if not self.debug_visualizer:
+        # Is the debug visualizer enabled?
+        if not self.debug_visualizer or len(self.debug_envs_idx) == 0:
+            return
+
+        # Don't update for every step
+        if self.env.step_count % self._steps_per_debug_render != 0:
             return
 
         # Remove existing arrows
@@ -229,58 +264,34 @@ class VelocityCommandManager(CommandManager):
             self.env.scene.clear_debug_object(arrow)
         self._arrow_nodes = []
 
-        # Scale the arrow size based on the maximum target velocity range
-        scale_factor = self.visualizer_cfg["arrow_max_length"] / max(
-            *self._range["lin_vel_x"],
-            *self._range["lin_vel_y"],
-            *self._range["ang_vel_z"],
-        )
-
-        # Calculate the center of the robot
-        aabb = self.env.robot.get_AABB()
-        min_aabb = aabb[:, 0]  # [min_x, min_y, min_z]
-        max_aabb = aabb[:, 1]  # [max_x, max_y, max_z]
-        robot_x = (min_aabb[:, 0] + max_aabb[:, 0]) / 2
-        robot_y = (min_aabb[:, 1] + max_aabb[:, 1]) / 2
-        robot_z = max_aabb[:, 2]
-
-        # Set the arrow position over the center of the robot
-        arrow_pos = torch.zeros(self.env.num_envs, 3, device=gs.device)
-        arrow_pos[:, 0] = robot_x
-        arrow_pos[:, 1] = robot_y
-        arrow_pos[:, 2] = robot_z + self.visualizer_cfg["arrow_offset"]
-        arrow_pos += torch.from_numpy(self.env.scene.envs_offset).to(gs.device)
-
-        # Get robot orientation (quaternion) for coordinate transformation
-        robot_quat = self.env.robot.get_quat()
+        # Calculate the arrow position over the robot
+        self._arrow_pos_buffer[:] = self.env.robot.get_pos()
+        self._arrow_pos_buffer[:, 2] += self.visualizer_cfg["arrow_offset"]
+        self._arrow_pos_buffer += self._scene_env_offset
 
         # Transform robot-relative velocity commands to world coordinates for visualization
-        target_velocity = self._resolve_xy_velocity_to_world_frame(
-            self.command[:, :2], robot_quat, scale_factor
-        )
+        target_velocity = self._target_velocity_in_world_frame()
 
         # Actual robot velocity (already in world coordinates)
-        actual_vec = self.env.robot.get_vel().clone()
-        actual_vec[:, 2] = 0.0
-        actual_vec[:, :] *= scale_factor
+        self._actual_vec_buffer[:] = self.env.robot.get_vel() * self._arrow_scale_factor
+        self._actual_vec_buffer[:, 2] = 0.0
 
         for i in self.debug_envs_idx:
             # Target arrow (robot-relative command transformed to world coordinates for visualization)
             self._draw_arrow(
-                pos=arrow_pos[i],
+                pos=self._arrow_pos_buffer[i],
                 vec=target_velocity[i],
                 color=self.visualizer_cfg["commanded_color"],
             )
+
             # Actual arrow
             self._draw_arrow(
-                pos=arrow_pos[i],
-                vec=actual_vec[i],
+                pos=self._arrow_pos_buffer[i],
+                vec=self._actual_vec_buffer[i],
                 color=self.visualizer_cfg["actual_color"],
             )
 
-    def _resolve_xy_velocity_to_world_frame(
-        self, xy_velocity: torch.Tensor, robot_quat: torch.Tensor, scale_factor: float
-    ) -> torch.Tensor:
+    def _target_velocity_in_world_frame(self) -> torch.Tensor:
         """
         Converts robot-relative XY velocity commands to world coordinates for visualization.
 
@@ -289,24 +300,20 @@ class VelocityCommandManager(CommandManager):
         2. Transforms them to world coordinates using the robot's current orientation
         3. Scales them for visualization
 
-        Args:
-            xy_velocity: Robot-relative velocity commands in base frame, shape (num_envs, 2)
-            robot_quat: Robot's current orientation quaternion, shape (num_envs, 4)
-            scale_factor: Scaling factor for visualization
-
         Returns:
             World-frame velocity vectors scaled for visualization, shape (num_envs, 3)
         """
         # Create 3D velocity tensor with Z component zeroed for 2D visualization
-        vec_3d = torch.zeros(xy_velocity.shape[0], 3, device=xy_velocity.device)
-        vec_3d[:, :2] = xy_velocity
+        self._vec_3d_buffer[:, :2] = self.command[:, :2]
+        self._vec_3d_buffer[:, 2] = 0.0
 
         # Transform from robot-relative (base) frame to world frame using quaternion
         # This is the inverse of what robot_lin_vel does
-        vec_world = transform_by_quat(vec_3d, robot_quat)
+        robot_quat = self.env.robot.get_quat()
+        vec_world = transform_by_quat(self._vec_3d_buffer, robot_quat)
 
         # Scale the transformed world velocity vector
-        vec_world[:, :] *= scale_factor
+        vec_world[:, :] *= self._arrow_scale_factor
 
         return vec_world
 
@@ -317,7 +324,7 @@ class VelocityCommandManager(CommandManager):
         color: list[float],
     ):
         # If velocity is zero, don't draw the arrow
-        if torch.all(vec == 0.0):
+        if not torch.any(vec != 0.0):
             return
         try:
             node = self.env.scene.draw_debug_arrow(

--- a/genesis_forge/managers/command/velocity_command.py
+++ b/genesis_forge/managers/command/velocity_command.py
@@ -6,13 +6,10 @@ import torch
 import genesis as gs
 
 from genesis_forge.genesis_env import GenesisEnv
-from genesis_forge.utils import entity_lin_vel, transform_by_quat
+from genesis_forge.utils import transform_by_quat
 from genesis_forge.gamepads import Gamepad
 
 from .command_manager import CommandManager, CommandRangeValue
-
-
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class VelocityCommandRange(TypedDict):

--- a/genesis_forge/managers/contact/config.py
+++ b/genesis_forge/managers/contact/config.py
@@ -16,10 +16,14 @@ class ContactDebugVisualizerConfig(TypedDict):
     force_threshold: float
     """The threshold, in Newtons, for the contact force to be visualized"""
 
+    fps: int
+    """The FPS of the debug visualization. Lower FPS means fewer frames are rendered, saving GPU memory."""
+
 
 DEFAULT_VISUALIZER_CONFIG: ContactDebugVisualizerConfig = {
     "envs_idx": None,
     "size": 0.03,
     "color": (0.5, 0.0, 0.0, 1.0),
     "force_threshold": 1.0,
+    "fps": 30,
 }

--- a/genesis_forge/managers/contact/contact_manager.py
+++ b/genesis_forge/managers/contact/contact_manager.py
@@ -445,9 +445,7 @@ class ContactManager(BaseManager):
 
         # Handle debug visualization
         if self.debug_visualizer:
-            self._render_debug_visualizer(
-                self.contacts.clone().detach(), self.contact_positions.clone().detach()
-            )
+            self._render_debug_visualizer(self.contacts, self.contact_positions)
 
     def _calculate_air_time(self):
         """

--- a/genesis_forge/managers/contact/contact_manager.py
+++ b/genesis_forge/managers/contact/contact_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 import torch
 import genesis as gs
@@ -294,6 +295,10 @@ class ContactManager(BaseManager):
         if self.debug_envs_idx is None:
             self.debug_envs_idx = list[int](range(self.env.num_envs))
 
+        # Calculate the number of steps per debug render
+        fps = self.visualizer_cfg.get("fps", 30)
+        self._steps_per_debug_render = math.ceil(1.0 / fps / self.env.dt)
+
         # Get the link indices
         (self._link_ids, self._local_link_ids) = self._get_links_idx(
             self._entity_attr, self._link_names
@@ -444,7 +449,10 @@ class ContactManager(BaseManager):
         )
 
         # Handle debug visualization
-        if self.debug_visualizer:
+        if (
+            self.debug_visualizer
+            and self.env.step_count % self._steps_per_debug_render == 0
+        ):
             self._render_debug_visualizer(self.contacts, self.contact_positions)
 
     def _calculate_air_time(self):

--- a/genesis_forge/managers/observation_manager.py
+++ b/genesis_forge/managers/observation_manager.py
@@ -22,7 +22,7 @@ class ObservationConfig(TypedDict):
 
     noise: float | None
     """The noise scale to add to the observation. If None, no noise will be added.
-    This will randomly choose a number between -1 and 1, multiply it by the noise scale, and add the result to the observation values."""
+    This will randomly choose 243 number between -1 gnd 1, multiply it by the noise scale, and add the result to the observation values."""
 
 
 class ObservationManager(BaseManager):
@@ -240,7 +240,9 @@ class ObservationManager(BaseManager):
                 cfg.build()
                 assert callable(cfg.fn), f"Observation function {name} is not callable"
                 value = cfg.fn(env=self.env, **cfg.params)
-                size += value.shape[1]
+                value_size = value.shape[-1]
+                if value_size > 0:
+                    size += value.shape[1]
             except Exception as e:
                 print(f"Error generating observation for '{name}'")
                 raise e
@@ -273,8 +275,9 @@ class ObservationManager(BaseManager):
 
                 # Copy directly into output buffer
                 value_size = value.shape[-1]
-                output[:, offset : offset + value_size] = value
-                offset += value_size
+                if value_size > 0:
+                    output[:, offset : offset + value_size] = value
+                    offset += value_size
             except Exception as e:
                 print(f"Error generating observation for '{name}'")
                 raise e

--- a/genesis_forge/managers/observation_manager.py
+++ b/genesis_forge/managers/observation_manager.py
@@ -191,14 +191,8 @@ class ObservationManager(BaseManager):
             )
             return
 
-        # Build any config item function classes.
-        for name, cfg in self.cfg.items():
-            cfg.build()
-            assert callable(cfg.fn), f"Observation function {name} is not callable"
-
-        # Make an initial observation and create the observation space
-        obs = self._perform_observation()
-        single_obs_size = obs.shape[1]
+        # Setup observation functions and the observation space
+        single_obs_size = self._setup_observation_functions()
         self._observation_size = single_obs_size * self._history_len
         self._observation_space = spaces.Box(
             low=-np.inf,
@@ -212,24 +206,54 @@ class ObservationManager(BaseManager):
         self._history = [
             torch.zeros(shape, device=gs.device) for _ in range(self._history_len)
         ]
+        self._history_output = torch.zeros(
+            (self.env.num_envs, self._observation_size),
+            device=gs.device,
+        )
 
     def get_observations(self) -> torch.Tensor:
         """Generate current observations for all environments."""
         if not self.enabled:
             return torch.zeros((self.env.num_envs, self._observation_size))
 
-        self._history.pop()
-        obs = self._perform_observation()
-        self._history.insert(0, obs)
-        return torch.cat(self._history, dim=-1)
+        buffer = self._history.pop()
+        self._perform_observation(buffer)
+        self._history.insert(0, buffer)
+
+        # Concatenate the history buffers into the pre-allocated output buffer
+        offset = 0
+        for hist_obs in self._history:
+            size = hist_obs.shape[1]
+            self._history_output[:, offset : offset + size] = hist_obs
+            offset += size
+        return self._history_output
 
     """
     Private methods.
     """
 
-    def _perform_observation(self) -> torch.Tensor:
-        """Perform a round of observations."""
-        obs = []
+    def _setup_observation_functions(self) -> int:
+        """Build all the observation function classes, and determine the observation space."""
+        size = 0
+        for name, cfg in self.cfg.items():
+            try:
+                cfg.build()
+                assert callable(cfg.fn), f"Observation function {name} is not callable"
+                value = cfg.fn(env=self.env, **cfg.params)
+                size += value.shape[1]
+            except Exception as e:
+                print(f"Error generating observation for '{name}'")
+                raise e
+        return size
+
+    def _perform_observation(self, output: torch.Tensor) -> torch.Tensor:
+        """
+        Perform a round of observations.
+
+        Args:
+            output: The output tensor to fill with the observations.
+        """
+        offset = 0
         for name, cfg in self.cfg.items():
             try:
                 # Get values
@@ -247,8 +271,11 @@ class ObservationManager(BaseManager):
                     noise_value = torch.empty_like(value).uniform_(-1, 1) * noise
                     value += noise_value
 
-                obs.append(value)
+                # Copy directly into output buffer
+                value_size = value.shape[-1]
+                output[:, offset : offset + value_size] = value
+                offset += value_size
             except Exception as e:
                 print(f"Error generating observation for '{name}'")
                 raise e
-        return torch.cat(obs, dim=-1)
+        return output

--- a/genesis_forge/managers/observation_manager.py
+++ b/genesis_forge/managers/observation_manager.py
@@ -243,7 +243,7 @@ class ObservationManager(BaseManager):
                 value = cfg.fn(env=self.env, **cfg.params)
                 value_size = value.shape[-1]
                 if value_size > 0:
-                    size += value.shape[1]
+                    size += value_size
             except Exception as e:
                 print(f"Error generating observation for '{name}'")
                 raise e

--- a/genesis_forge/managers/observation_manager.py
+++ b/genesis_forge/managers/observation_manager.py
@@ -22,7 +22,7 @@ class ObservationConfig(TypedDict):
 
     noise: float | None
     """The noise scale to add to the observation. If None, no noise will be added.
-    This will randomly choose 243 number between -1 gnd 1, multiply it by the noise scale, and add the result to the observation values."""
+    This will randomly choose a number between -1 and 1, multiply it by the noise scale, and add the result to the observation values."""
 
 
 class ObservationManager(BaseManager):

--- a/genesis_forge/managers/observation_manager.py
+++ b/genesis_forge/managers/observation_manager.py
@@ -221,12 +221,13 @@ class ObservationManager(BaseManager):
         self._history.insert(0, buffer)
 
         # Concatenate the history buffers into the pre-allocated output buffer
+        # This is more performant than torch.cat()
         offset = 0
-        for hist_obs in self._history:
-            size = hist_obs.shape[1]
-            self._history_output[:, offset : offset + size] = hist_obs
+        for obs in self._history:
+            size = obs.shape[1]
+            self._history_output[:, offset : offset + size] = obs
             offset += size
-        return self._history_output
+        return self._history_output.clone()
 
     """
     Private methods.

--- a/genesis_forge/managers/terrain_manager.py
+++ b/genesis_forge/managers/terrain_manager.py
@@ -177,7 +177,7 @@ class TerrainManager(BaseManager):
         subterrain: str | None = None,
         height_offset: float = 0.1e-3,
         output: torch.Tensor | None = None,
-        out_idx: torch.Tensor | None = None,
+        out_idx: torch.Tensor | list[int] | None = None,
     ) -> torch.Tensor:
         """
         Distribute X/Y/Z positions across the terrain or subterrain.
@@ -187,6 +187,7 @@ class TerrainManager(BaseManager):
             num: The number of positions to generate. Not necessary if output is provided
             output: The position tensor to update in-place.
             out_idx: The indices of the output position tensor to update.
+                     Can be a list of ints or a torch.Tensor for better performance.
             usable_ratio: How much of the terrain/subterrain area should be used for random positions.
                           For example, 0.25 will only generate positions within the center 25% of the area of the terrain/subterrain.
                           This helps avoid placing things right on th edge of the terrain/subterrain.
@@ -206,6 +207,8 @@ class TerrainManager(BaseManager):
             output = torch.zeros(num, 3, device=gs.device)
         if out_idx is None:
             out_idx = torch.arange(output.shape[0], device=gs.device)
+        elif isinstance(out_idx, list):
+            out_idx = torch.tensor(out_idx, device=gs.device, dtype=torch.long)
         if num is None:
             num = out_idx.shape[0]
 
@@ -231,24 +234,20 @@ class TerrainManager(BaseManager):
         y_min = y_origin + buffer_y_size
         y_max = y_origin + y_size - buffer_y_size
 
-        # Generate random positions in-place to avoid memory allocation
-        output[out_idx, 0] = (
-            torch.rand_like(output[out_idx, 0]) * (x_max - x_min) + x_min
-        )
-        output[out_idx, 1] = (
-            torch.rand_like(output[out_idx, 1]) * (y_max - y_min) + y_min
-        )
-
-        # Get terrain heights
+        # Generate random positions and get the height at those points
+        output[out_idx, 0].uniform_(x_min, x_max)
+        output[out_idx, 1].uniform_(y_min, y_max)
         terrain_heights = self.get_terrain_height(
             output[out_idx, 0], output[out_idx, 1]
         )
+
+        # Add the height offset
         output[out_idx, 2] = terrain_heights + height_offset
         return output
 
     def generate_random_env_pos(
         self,
-        envs_idx: list[int] | None = None,
+        envs_idx: list[int] | torch.Tensor | None = None,
         usable_ratio: float = 0.5,
         subterrain: str | None = None,
         height_offset: float = 0.1e-3,
@@ -260,6 +259,7 @@ class TerrainManager(BaseManager):
         Args:
             envs_idx: The indices of the environments to generate positions for.
                       If None, positions will be generated for all environments.
+                      Can be a list of ints or a torch.Tensor for better performance.
             usable_ratio: How much of the terrain/subterrain area should be used for random positions.
                           For example, 0.25 will only generate positions within the center 25% of the area of the terrain/subterrain.
                           This helps avoid placing things right on th edge of the terrain/subterrain.
@@ -272,6 +272,8 @@ class TerrainManager(BaseManager):
         """
         if envs_idx is None:
             envs_idx = torch.arange(self.env.num_envs, device=gs.device)
+        elif isinstance(envs_idx, list):
+            envs_idx = torch.tensor(envs_idx, device=gs.device, dtype=torch.long)
 
         # Update the position buffer in-place
         self.generate_random_positions(

--- a/genesis_forge/managers/terrain_manager.py
+++ b/genesis_forge/managers/terrain_manager.py
@@ -234,15 +234,18 @@ class TerrainManager(BaseManager):
         y_min = y_origin + buffer_y_size
         y_max = y_origin + y_size - buffer_y_size
 
-        # Generate random positions and get the height at those points
-        output[out_idx, 0].uniform_(x_min, x_max)
-        output[out_idx, 1].uniform_(y_min, y_max)
-        terrain_heights = self.get_terrain_height(
-            output[out_idx, 0], output[out_idx, 1]
-        )
+        # Generate random positions
+        x_rand = torch.empty(num, device=gs.device, dtype=gs.tc_float)
+        y_rand = torch.empty(num, device=gs.device, dtype=gs.tc_float)
+        x_rand.uniform_(x_min, x_max)
+        y_rand.uniform_(y_min, y_max)
 
-        # Add the height offset
+        # Get terrain heights at these positions
+        terrain_heights = self.get_terrain_height(x_rand, y_rand)
+        output[out_idx, 0] = x_rand
+        output[out_idx, 1] = y_rand
         output[out_idx, 2] = terrain_heights + height_offset
+        
         return output
 
     def generate_random_env_pos(

--- a/genesis_forge/mdp/reset.py
+++ b/genesis_forge/mdp/reset.py
@@ -180,18 +180,19 @@ class randomize_terrain_position(ResetMdpFnClass):
         x = rotation["x"] if "x" in rotation else 0
         y = rotation["y"] if "y" in rotation else 0
         z = rotation["z"] if "z" in rotation else 0
+        n_envs = len(envs_idx)
 
         if isinstance(x, tuple):
             self._rotation_buffer[envs_idx, 0] = torch.empty(
-                len(envs_idx), device=gs.device
+                n_envs, device=gs.device
             ).uniform_(*x)
         if isinstance(y, tuple):
             self._rotation_buffer[envs_idx, 1] = torch.empty(
-                len(envs_idx), device=gs.device
+                n_envs, device=gs.device
             ).uniform_(*y)
         if isinstance(z, tuple):
             self._rotation_buffer[envs_idx, 2] = torch.empty(
-                len(envs_idx), device=gs.device
+                n_envs, device=gs.device
             ).uniform_(*z)
 
         # Set angle as quat


### PR DESCRIPTION
A variety of performance tuning tweaks to make training faster. Mostly, not recreating tensor buffers when unnecessary. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preallocates/reuses buffers and uses in-place ops across env/managers, adds FPS-based throttling to debug visualizers, optimizes observation assembly, and restructures actuator noise/value buffers.
> 
> - **Core/env**
>   - Use `torch.empty_like` and in-place copies for `actions`/`last_actions`; fix `reset` to init `_last_actions` from `_actions`.
>   - Managed env stores observations in pre-allocated `TensorDict` (`_observations_buf`) and exposes via `extras`.
> - **Actions/Actuators**
>   - Action manager: avoid clones by allocating once and copying in-place.
>   - Actuator manager: introduce `noise_buffer` and `output_buffer`; apply noise without cloning; expand buffers via `repeat`; minor doc tweaks.
> - **Observations**
>   - Observation manager: split setup into `_setup_observation_functions`; pre-allocate history/output buffers; build observations via in-place slicing instead of `torch.cat`.
> - **Commands/Velocity Debug**
>   - Add `fps` to visualizer config; compute steps-per-render; pre-allocate position/velocity buffers; reuse scene env offset; adjust `arrow_offset`; factor world-frame transform; skip zero vectors.
> - **Contacts**
>   - Add `fps` to visualizer config and throttle rendering; pass tensors directly (no clone/detach) to visualizer.
> - **Terrain**
>   - Random position generation uses temporary rand buffers and supports list/`Tensor` indices; returns heights with minimal allocation; same support in `generate_random_env_pos`.
> - **MDP/Reset**
>   - Use cached env count when sampling Euler angles for quats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac184e90e3125977ba81998bf243d0a57f3c76f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->