### PR TITLE
Support multiple action managers

### DIFF
--- a/examples/multiple_action_managers/README.md
+++ b/examples/multiple_action_managers/README.md
@@ -1,0 +1,35 @@
+# Multiple Action Managers
+
+Demonstrates using multliple action managers for a single robot.
+
+## Training
+
+This will be trained using the [rsl_rl](https://github.com/leggedrobotics/rsl_rl) training library. So first, we need to install that and tensorboard:
+
+```bash
+pip install tensorboard rsl-rl-lib>=2.2.4
+```
+
+Now you can run the training with:
+
+```bash
+python ./train.py
+```
+
+You can view the training progress with:
+
+```bash
+tensorboard --logdir ./logs/
+```
+
+The Genesis Forge training environment will also save videos while training that can be viewed in `./logs/go2-walking/videos`.
+
+https://github.com/user-attachments/assets/be46df1b-35e5-4b5b-9bbc-f543210dd463
+
+## Evaluation
+
+Now you can view the trained policy:
+
+```bash
+python ./eval.py ./logs/go2-walking/
+```

--- a/examples/multiple_action_managers/README.md
+++ b/examples/multiple_action_managers/README.md
@@ -15,7 +15,7 @@ self.hip_action_manager = PositionWithinLimitsActionManager(
     self,
     actuator_manager=self.actuator_manager,
     actuator_joints=[".*_hip_joint"],
-    limit=(-0.8, 0.8),
+    limit=(-0.6, 0.6),
 )
 self.leg_action_manager = PositionActionManager(
     self,

--- a/examples/multiple_action_managers/README.md
+++ b/examples/multiple_action_managers/README.md
@@ -1,6 +1,33 @@
 # Multiple Action Managers
 
-Demonstrates using multliple action managers for a single robot.
+Demonstrates using multiple action managers for a single robot. This can be useful if some actuators need to be controlled differently
+from each other. Currently, Genesis Forge only has two types of positional action managers, but in the future, it will likely be expanded
+to include velocity or torque based action managers.
+
+To use multiple action managers, you pass a filter to each, specifying which actuators it should control:
+
+```python
+# First define your actuator manager
+self.actuator_manager = ActuatorManager(self, joint_names=".*", kp=20, kv=0.5)
+
+# Then define your action managers
+self.hip_action_manager = PositionWithinLimitsActionManager(
+    self,
+    actuator_manager=self.actuator_manager,
+    actuator_joints=[".*_hip_joint"],
+    limit=(-0.8, 0.8),
+)
+self.leg_action_manager = PositionActionManager(
+    self,
+    actuator_manager=self.actuator_manager,
+    actuator_joints=[
+        ".*_thigh_joint",
+        ".*_calf_joint",
+    ],
+    scale=0.25,
+    clip=(-100.0, 100.0),
+)
+```
 
 ## Training
 

--- a/examples/multiple_action_managers/environment.py
+++ b/examples/multiple_action_managers/environment.py
@@ -138,7 +138,11 @@ class Go2SimpleEnv(ManagedEnvironment):
             kp=20,
             kv=0.5,
         )
-
+        self.hip_action_manager = PositionWithinLimitsActionManager(
+            self,
+            actuator_manager=self.actuator_manager,
+            actuator_filter=[".*_hip_joint"],
+        )
         self.leg_action_manager = PositionActionManager(
             self,
             actuator_manager=self.actuator_manager,
@@ -149,11 +153,6 @@ class Go2SimpleEnv(ManagedEnvironment):
             scale=0.25,
             clip=(-100.0, 100.0),
             use_default_offset=True,
-        )
-        self.hip_action_manager = PositionWithinLimitsActionManager(
-            self,
-            actuator_manager=self.actuator_manager,
-            actuator_filter=[".*_hip_joint"],
         )
 
         ##

--- a/examples/multiple_action_managers/environment.py
+++ b/examples/multiple_action_managers/environment.py
@@ -1,0 +1,263 @@
+"""
+Simplified Go2 Locomotion Environment using managers to handle everything.
+"""
+
+import torch
+import genesis as gs
+
+from genesis_forge import ManagedEnvironment
+from genesis_forge.managers import (
+    RewardManager,
+    TerminationManager,
+    EntityManager,
+    ObservationManager,
+    ActuatorManager,
+    PositionActionManager,
+    PositionWithinLimitsActionManager,
+)
+from genesis_forge.mdp import reset, rewards, terminations
+
+
+INITIAL_BODY_POSITION = [0.0, 0.0, 0.4]
+INITIAL_QUAT = [1.0, 0.0, 0.0, 0.0]
+TARGET_X_VELOCITY = 0.5
+
+
+class Go2SimpleEnv(ManagedEnvironment):
+    """
+    Example training environment for the Go2 robot.
+    """
+
+    def __init__(
+        self,
+        num_envs: int = 1,
+        dt: float = 1 / 50,  # control frequency on real robot is 50hz
+        max_episode_length_s: int | None = 20,
+        headless: bool = True,
+    ):
+        super().__init__(
+            num_envs=num_envs,
+            dt=dt,
+            max_episode_length_sec=max_episode_length_s,
+            max_episode_random_scaling=0.1,
+        )
+
+        # Set the commanded robot direction to be 0.5 along the X axis, for all environments
+        self.target_command = torch.zeros(
+            (self.num_envs, 3), device=gs.device, dtype=gs.tc_float
+        )
+        self.target_command[:, 0] = (
+            TARGET_X_VELOCITY  # Linear velocity along the X axis
+        )
+
+        # Construct the scene
+        self.scene = gs.Scene(
+            show_viewer=not headless,
+            sim_options=gs.options.SimOptions(dt=self.dt, substeps=2),
+            viewer_options=gs.options.ViewerOptions(
+                max_FPS=int(0.5 / self.dt),
+                camera_pos=(2.0, 0.0, 2.5),
+                camera_lookat=(0.0, 0.0, 0.5),
+                camera_fov=40,
+            ),
+            vis_options=gs.options.VisOptions(rendered_envs_idx=list(range(1))),
+            rigid_options=gs.options.RigidOptions(
+                dt=self.dt,
+                constraint_solver=gs.constraint_solver.Newton,
+                enable_collision=True,
+                enable_joint_limit=True,
+                # for this locomotion policy there are usually no more than 30 collision pairs
+                # set a low value can save memory
+                max_collision_pairs=30,
+            ),
+        )
+
+        # Create terrain
+        self.terrain = self.scene.add_entity(gs.morphs.Plane())
+
+        # Robot
+        self.robot = self.scene.add_entity(
+            gs.morphs.URDF(
+                file="urdf/go2/urdf/go2.urdf",
+                pos=INITIAL_BODY_POSITION,
+                quat=INITIAL_QUAT,
+            ),
+        )
+
+        # Camera, for headless video recording
+        self.camera = self.scene.add_camera(
+            pos=(-2.5, -1.5, 1.0),
+            lookat=(0.0, 0.0, 0.0),
+            res=(1280, 720),
+            fov=40,
+            env_idx=0,
+            debug=True,
+        )
+
+    def config(self):
+        """
+        Configure the environment managers
+        """
+        ##
+        # Robot manager
+        # i.e. what to do with the robot when it is reset
+        self.robot_manager = EntityManager(
+            self,
+            entity_attr="robot",
+            on_reset={
+                # Reset the robot's initial position
+                "position": {
+                    "fn": reset.position,
+                    "params": {
+                        "position": INITIAL_BODY_POSITION,
+                        "quat": INITIAL_QUAT,
+                        "zero_velocity": True,
+                    },
+                },
+            },
+        )
+
+        ##
+        # Joint Actions
+        self.actuator_manager = ActuatorManager(
+            self,
+            joint_names=[
+                "FL_.*_joint",
+                "FR_.*_joint",
+                "RL_.*_joint",
+                "RR_.*_joint",
+            ],
+            default_pos={
+                ".*_hip_joint": 0.0,
+                "FL_thigh_joint": 0.8,
+                "FR_thigh_joint": 0.8,
+                "RL_thigh_joint": 1.0,
+                "RR_thigh_joint": 1.0,
+                ".*_calf_joint": -1.5,
+            },
+            kp=20,
+            kv=0.5,
+        )
+
+        self.leg_action_manager = PositionActionManager(
+            self,
+            actuator_manager=self.actuator_manager,
+            actuator_filter=[
+                ".*_thigh_joint",
+                ".*_calf_joint",
+            ],
+            scale=0.25,
+            clip=(-100.0, 100.0),
+            use_default_offset=True,
+        )
+        self.hip_action_manager = PositionWithinLimitsActionManager(
+            self,
+            actuator_manager=self.actuator_manager,
+            actuator_filter=[".*_hip_joint"],
+        )
+
+        ##
+        # Rewards
+        RewardManager(
+            self,
+            logging_enabled=True,
+            cfg={
+                "base_height_target": {
+                    "weight": -50.0,
+                    "fn": rewards.base_height,
+                    "params": {
+                        "target_height": 0.3,
+                        "entity_attr": "robot",
+                    },
+                },
+                "tracking_lin_vel": {
+                    "weight": 1.0,
+                    "fn": rewards.command_tracking_lin_vel,
+                    "params": {
+                        "command": self.target_command[:, :2],
+                        "entity_manager": self.robot_manager,
+                    },
+                },
+                "tracking_ang_vel": {
+                    "weight": 0.2,
+                    "fn": rewards.command_tracking_ang_vel,
+                    "params": {
+                        "commanded_ang_vel": self.target_command[:, 2],
+                        "entity_manager": self.robot_manager,
+                    },
+                },
+                "lin_vel_z": {
+                    "weight": -1.0,
+                    "fn": rewards.lin_vel_z_l2,
+                    "params": {
+                        "entity_manager": self.robot_manager,
+                    },
+                },
+                "action_rate": {
+                    "weight": -0.005,
+                    "fn": rewards.action_rate_l2,
+                },
+                "similar_to_default": {
+                    "weight": -0.1,
+                    "fn": rewards.dof_similar_to_default,
+                    "params": {
+                        "action_manager": self.leg_action_manager,
+                    },
+                },
+            },
+        )
+
+        ##
+        # Termination conditions
+        self.termination_manager = TerminationManager(
+            self,
+            logging_enabled=True,
+            term_cfg={
+                # The episode ended
+                "timeout": {
+                    "fn": terminations.timeout,
+                    "time_out": True,
+                },
+                # Terminate if the robot's pitch and yaw angles are too large
+                "fall_over": {
+                    "fn": terminations.bad_orientation,
+                    "params": {
+                        "limit_angle": 10.0,
+                        "entity_manager": self.robot_manager,
+                    },
+                },
+            },
+        )
+
+        ##
+        # Observations
+        ObservationManager(
+            self,
+            cfg={
+                "angle_velocity": {
+                    "fn": lambda env: self.robot_manager.get_angular_velocity(),
+                    "scale": 0.25,
+                },
+                "linear_velocity": {
+                    "fn": lambda env: self.robot_manager.get_linear_velocity(),
+                    "scale": 2.0,
+                },
+                "projected_gravity": {
+                    "fn": lambda env: self.robot_manager.get_projected_gravity(),
+                },
+                "dof_position": {
+                    "fn": lambda env: self.leg_action_manager.get_dofs_position(),
+                },
+                "dof_velocity": {
+                    "fn": lambda env: self.leg_action_manager.get_dofs_velocity(),
+                    "scale": 0.05,
+                },
+                "actions": {
+                    "fn": lambda env: self.leg_action_manager.get_actions(),
+                },
+            },
+        )
+
+    def build(self):
+        super().build()
+        self.camera.follow_entity(self.robot)

--- a/examples/multiple_action_managers/environment.py
+++ b/examples/multiple_action_managers/environment.py
@@ -66,8 +66,6 @@ class Go2SimpleEnv(ManagedEnvironment):
                 constraint_solver=gs.constraint_solver.Newton,
                 enable_collision=True,
                 enable_joint_limit=True,
-                # for this locomotion policy there are usually no more than 30 collision pairs
-                # set a low value can save memory
                 max_collision_pairs=30,
             ),
         )
@@ -141,12 +139,13 @@ class Go2SimpleEnv(ManagedEnvironment):
         self.hip_action_manager = PositionWithinLimitsActionManager(
             self,
             actuator_manager=self.actuator_manager,
-            actuator_filter=[".*_hip_joint"],
+            actuator_joints=[".*_hip_joint"],
+            limit=(-0.8, 0.8),
         )
         self.leg_action_manager = PositionActionManager(
             self,
             actuator_manager=self.actuator_manager,
-            actuator_filter=[
+            actuator_joints=[
                 ".*_thigh_joint",
                 ".*_calf_joint",
             ],
@@ -245,13 +244,16 @@ class Go2SimpleEnv(ManagedEnvironment):
                     "fn": lambda env: self.robot_manager.get_projected_gravity(),
                 },
                 "dof_position": {
-                    "fn": lambda env: self.leg_action_manager.get_dofs_position(),
+                    "fn": lambda env: self.actuator_manager.get_dofs_position(),
                 },
                 "dof_velocity": {
-                    "fn": lambda env: self.leg_action_manager.get_dofs_velocity(),
+                    "fn": lambda env: self.actuator_manager.get_dofs_velocity(),
                     "scale": 0.05,
                 },
-                "actions": {
+                "hip_actions": {
+                    "fn": lambda env: self.hip_action_manager.get_actions(),
+                },
+                "leg_actions": {
                     "fn": lambda env: self.leg_action_manager.get_actions(),
                 },
             },

--- a/examples/multiple_action_managers/environment.py
+++ b/examples/multiple_action_managers/environment.py
@@ -140,7 +140,7 @@ class Go2SimpleEnv(ManagedEnvironment):
             self,
             actuator_manager=self.actuator_manager,
             actuator_joints=[".*_hip_joint"],
-            limit=(-0.8, 0.8),
+            limit=(-0.6, 0.6),
         )
         self.leg_action_manager = PositionActionManager(
             self,

--- a/examples/multiple_action_managers/environment.py
+++ b/examples/multiple_action_managers/environment.py
@@ -42,7 +42,7 @@ class Go2SimpleEnv(ManagedEnvironment):
             max_episode_random_scaling=0.1,
         )
 
-        # Set the commanded robot direction to be 0.5 along the X axis, for all environments
+        # Set the target robot direction, along the X axis
         self.target_command = torch.zeros(
             (self.num_envs, 3), device=gs.device, dtype=gs.tc_float
         )

--- a/examples/multiple_action_managers/eval.py
+++ b/examples/multiple_action_managers/eval.py
@@ -1,0 +1,89 @@
+import os
+import glob
+import torch
+import pickle
+import argparse
+from importlib import metadata
+import genesis as gs
+
+from genesis_forge.wrappers import RslRlWrapper
+from environment import Go2SimpleEnv
+
+try:
+    try:
+        if metadata.version("rsl-rl"):
+            raise ImportError
+    except metadata.PackageNotFoundError:
+        if metadata.version("rsl-rl-lib").startswith("1."):
+            raise ImportError
+except (metadata.PackageNotFoundError, ImportError) as e:
+    raise ImportError("Please install install 'rsl-rl-lib>=2.2.4'.") from e
+from rsl_rl.runners import OnPolicyRunner
+
+EXPERIMENT_NAME = "go2-multi"
+
+parser = argparse.ArgumentParser(add_help=True)
+parser.add_argument("-d", "--device", type=str, default="gpu")
+parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
+args = parser.parse_args()
+
+
+def get_latest_model(log_dir: str) -> str:
+    """
+    Get the last model from the log directory
+    """
+    model_checkpoints = glob.glob(os.path.join(log_dir, "model_*.pt"))
+    if len(model_checkpoints) == 0:
+        print(
+            f"Warning: No model files found at '{log_dir}' (you might need to train more)."
+        )
+        exit(1)
+    # Sort by the file with the highest number
+    sorted_models = sorted(
+        model_checkpoints,
+        key=lambda x: int(os.path.basename(x).split("_")[1].split(".")[0]),
+    )
+    return sorted_models[-1]
+
+
+def main():
+    # Processor backend (GPU or CPU)
+    backend = gs.gpu
+    if args.device == "cpu":
+        backend = gs.cpu
+        torch.set_default_device("cpu")
+    gs.init(logging_level="warning", backend=backend)
+
+    # Load training configuration
+    log_path = f"./logs/{args.exp_name}"
+    [cfg] = pickle.load(open(f"{log_path}/cfgs.pkl", "rb"))
+    model = get_latest_model(log_path)
+
+    # Setup environment
+    env = Go2SimpleEnv(num_envs=1, headless=False)
+    env = RslRlWrapper(env)
+    env.build()
+
+    # Eval
+    print("🎬 Loading last model...")
+    runner = OnPolicyRunner(env, cfg, log_path, device=gs.device)
+    runner.load(model)
+    policy = runner.get_inference_policy(device=gs.device)
+
+    try:
+        obs, _ = env.reset()
+        with torch.no_grad():
+            while True:
+                actions = policy(obs)
+                obs, _rews, _dones, _infos = env.step(actions)
+    except KeyboardInterrupt:
+        pass
+    except gs.GenesisException as e:
+        if e.message != "Viewer closed.":
+            raise e
+    except Exception as e:
+        raise e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multiple_action_managers/train.py
+++ b/examples/multiple_action_managers/train.py
@@ -1,0 +1,134 @@
+import os
+import copy
+import torch
+import shutil
+import pickle
+import argparse
+from importlib import metadata
+import genesis as gs
+
+from genesis_forge.wrappers import (
+    VideoWrapper,
+    RslRlWrapper,
+)
+from environment import Go2SimpleEnv
+
+try:
+    try:
+        if metadata.version("rsl-rl"):
+            raise ImportError
+    except metadata.PackageNotFoundError:
+        if metadata.version("rsl-rl-lib").startswith("1."):
+            raise ImportError
+except (metadata.PackageNotFoundError, ImportError) as e:
+    raise ImportError("Please install install 'rsl-rl-lib>=2.2.4'.") from e
+from rsl_rl.runners import OnPolicyRunner
+
+EXPERIMENT_NAME = "go2-multi"
+
+parser = argparse.ArgumentParser(add_help=True)
+parser.add_argument("-n", "--num_envs", type=int, default=4096)
+parser.add_argument("--max_iterations", type=int, default=101)
+parser.add_argument("-d", "--device", type=str, default="gpu")
+parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
+args = parser.parse_args()
+
+
+def training_cfg(exp_name: str, max_iterations: int):
+    return {
+        "algorithm": {
+            "class_name": "PPO",
+            "clip_param": 0.2,
+            "desired_kl": 0.01,
+            "entropy_coef": 0.01,
+            "gamma": 0.99,
+            "lam": 0.95,
+            "learning_rate": 0.001,
+            "max_grad_norm": 1.0,
+            "num_learning_epochs": 5,
+            "num_mini_batches": 4,
+            "schedule": "adaptive",
+            "use_clipped_value_loss": True,
+            "value_loss_coef": 1.0,
+        },
+        "init_member_classes": {},
+        "policy": {
+            "activation": "elu",
+            "actor_hidden_dims": [512, 256, 128],
+            "critic_hidden_dims": [512, 256, 128],
+            "init_noise_std": 1.0,
+            "class_name": "ActorCritic",
+        },
+        "runner": {
+            "checkpoint": -1,
+            "experiment_name": exp_name,
+            "load_run": -1,
+            "log_interval": 1,
+            "max_iterations": max_iterations,
+            "record_interval": -1,
+            "resume": False,
+            "resume_path": None,
+            "run_name": "",
+        },
+        "runner_class_name": "OnPolicyRunner",
+        "seed": 1,
+        "num_steps_per_env": 24,
+        "save_interval": 100,
+        "empirical_normalization": None,
+        "obs_groups": {"policy": ["policy"], "critic": ["policy"]},
+    }
+
+
+def main():
+    # Initialize Genesis
+    # Processor backend (GPU or CPU)
+    backend = gs.gpu
+    if args.device == "cpu":
+        backend = gs.cpu
+        torch.set_default_device("cpu")
+    gs.init(logging_level="warning", backend=backend, performance_mode=True)
+
+    # Logging directory
+    log_base_dir = "./logs"
+    experiment_name = args.exp_name
+    log_path = os.path.join(log_base_dir, experiment_name)
+    if os.path.exists(log_path):
+        shutil.rmtree(log_path)
+    os.makedirs(log_path, exist_ok=True)
+    print(f"Logging to: {log_path}")
+
+    # Load training configuration and save snapshot of training configs
+    cfg = training_cfg(experiment_name, args.max_iterations)
+    pickle.dump(
+        [cfg],
+        open(os.path.join(log_path, "cfgs.pkl"), "wb"),
+    )
+
+    # Create environment
+    env = Go2SimpleEnv(num_envs=args.num_envs, headless=True)
+
+    # Record videos in regular intervals
+    env = VideoWrapper(
+        env,
+        video_length_sec=12,
+        out_dir=os.path.join(log_path, "videos"),
+        episode_trigger=lambda episode_id: episode_id % 5 == 0,
+    )
+
+    # Build the environment
+    env = RslRlWrapper(env)
+    env.build()
+    env.reset()
+
+    # Train
+    print("💪 Training model...")
+    runner = OnPolicyRunner(env, copy.deepcopy(cfg), log_path, device=gs.device)
+    runner.git_status_repos = ["."]
+    runner.learn(
+        num_learning_iterations=args.max_iterations, init_at_random_ep_len=False
+    )
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multiple_action_managers/train.py
+++ b/examples/multiple_action_managers/train.py
@@ -28,7 +28,7 @@ EXPERIMENT_NAME = "go2-multi"
 
 parser = argparse.ArgumentParser(add_help=True)
 parser.add_argument("-n", "--num_envs", type=int, default=4096)
-parser.add_argument("--max_iterations", type=int, default=101)
+parser.add_argument("--max_iterations", type=int, default=450)
 parser.add_argument("-d", "--device", type=str, default="gpu")
 parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
 args = parser.parse_args()

--- a/examples/multiple_action_managers/train.py
+++ b/examples/multiple_action_managers/train.py
@@ -28,7 +28,7 @@ EXPERIMENT_NAME = "go2-multi"
 
 parser = argparse.ArgumentParser(add_help=True)
 parser.add_argument("-n", "--num_envs", type=int, default=4096)
-parser.add_argument("--max_iterations", type=int, default=250)
+parser.add_argument("--max_iterations", type=int, default=235)
 parser.add_argument("-d", "--device", type=str, default="gpu")
 parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
 args = parser.parse_args()

--- a/examples/multiple_action_managers/train.py
+++ b/examples/multiple_action_managers/train.py
@@ -28,7 +28,7 @@ EXPERIMENT_NAME = "go2-multi"
 
 parser = argparse.ArgumentParser(add_help=True)
 parser.add_argument("-n", "--num_envs", type=int, default=4096)
-parser.add_argument("--max_iterations", type=int, default=450)
+parser.add_argument("--max_iterations", type=int, default=250)
 parser.add_argument("-d", "--device", type=str, default="gpu")
 parser.add_argument("-e", "--exp_name", type=str, default=EXPERIMENT_NAME)
 args = parser.parse_args()

--- a/examples/simple/environment.py
+++ b/examples/simple/environment.py
@@ -41,7 +41,7 @@ class Go2SimpleEnv(ManagedEnvironment):
             max_episode_random_scaling=0.1,
         )
 
-        # Set the commanded robot direction to be 0.5 along the X axis, for all environments
+        # Set the target robot direction, along the X axis
         self.target_command = torch.zeros(
             (self.num_envs, 3), device=gs.device, dtype=gs.tc_float
         )

--- a/genesis_forge/managers/action/base.py
+++ b/genesis_forge/managers/action/base.py
@@ -1,9 +1,23 @@
+import re
 import torch
 import numpy as np
 from gymnasium import spaces
 import genesis as gs
 from genesis_forge.genesis_env import GenesisEnv
+from genesis_forge.managers.actuator import ActuatorManager
 from genesis_forge.managers.base import BaseManager
+
+deprecated_arg_names = [
+    "joint_names",
+    "default_pos",
+    "pd_kp",
+    "pd_kv",
+    "max_force",
+    "damping",
+    "stiffness",
+    "frictionloss",
+    "noise_scale",
+]
 
 
 class BaseActionManager(BaseManager):
@@ -12,32 +26,104 @@ class BaseActionManager(BaseManager):
 
     Args:
         env: The environment to manage the DOF actuators for.
+        actuator_manager: The actuator manager which is used to setup and control the DOF joints.
+        actuator_filter: Which joints of the actuator manager that this action manager will control.
+                   These can be full names or regular expressions.
         delay_step: The number of steps to delay the actions for.
                     This is an easy way to emulate the latency in the system.
     """
 
-    def __init__(self, env: GenesisEnv, delay_step: int = 0):
+    def __init__(
+        self,
+        env: GenesisEnv,
+        actuator_manager: ActuatorManager | None = None,
+        actuator_filter: list[str] | str = ".*",
+        delay_step: int = 0,
+        **kwargs,
+    ):
         super().__init__(env, type="action")
         self._raw_actions = None
         self._actions = None
         self._delay_step = delay_step
         self._action_delay_buffer = []
+        self._actuator_manager = actuator_manager
+        self._actuator_filter = (
+            [actuator_filter] if isinstance(actuator_filter, str) else actuator_filter
+        )
+        self._dofs: dict[int, str] = {}
+        self._actuator_dof_filter: torch.Tensor = None
+
+        # Deprecated actuator parameters
+        deprecated_actuator_args = {
+            key: kwargs[key] for key in deprecated_arg_names if key in kwargs
+        }
+        if len(deprecated_actuator_args) > 0:
+            dep_list = ", ".join(deprecated_actuator_args.keys())
+            if self._actuator_manager is not None:
+                raise ValueError(
+                    f"Cannot set both actuator_manager and deprecated actuator parameters: {dep_list}"
+                )
+            print(
+                f"Actuator arguments are deprecated in the action manager, instead define an ActuatorManager ({dep_list})"
+            )
+            self._actuator_manager = ActuatorManager(
+                env,
+                joint_names=kwargs.get("joint_names", ".*"),
+                default_pos=kwargs.get("default_pos", {".*": 0.0}),
+                kp=kwargs.get("pd_kp", None),
+                kv=kwargs.get("pd_kv", None),
+                max_force=kwargs.get("max_force", None),
+                damping=kwargs.get("damping", None),
+                stiffness=kwargs.get("stiffness", None),
+                frictionloss=kwargs.get("frictionloss", None),
+                default_noise_scale=kwargs.get("noise_scale", 0.0),
+            )
+        if self._actuator_manager is None:
+            raise ValueError("No ActuatorManager provided.")
 
     """
     Properties
     """
 
     @property
+    def actuators(self) -> ActuatorManager:
+        """
+        Get the actuator manager.
+        """
+        return self._actuator_manager
+
+    @property
     def num_actions(self) -> int:
         """
-        The total number of actions.
+        Get the number of actions.
         """
-        return 0
+        return len(self.dofs_idx)
+
+    @property
+    def dofs_idx(self) -> list[int]:
+        """
+        Get the indices of the DOFs that this action manager controls.
+        """
+        return list[int](self._dofs.values())
+
+    @property
+    def dofs(self) -> dict[str, int]:
+        """
+        Get a dictionary of the DOF names and their indices
+        """
+        return self._dofs
+
+    @property
+    def actuator_dof_filter(self) -> torch.Tensor:
+        """
+        An index filer for actuator DOF values.
+        """
+        return self._actuator_dof_filter
 
     @property
     def action_space(self) -> tuple[float, float]:
         """
-        If using the default action handler, the action space is [-1, 1].
+        Returns the actions space for the environment, based on the number of DOFs defined in this action manager.
         """
         return spaces.Box(
             low=-np.inf,
@@ -63,6 +149,28 @@ class BaseActionManager(BaseManager):
         if self._raw_actions is None:
             return torch.zeros((self.env.num_envs, self.num_actions))
         return self._raw_actions
+
+    """
+    Lifecycle Operations
+    """
+
+    def build(self):
+        """
+        Builds the manager and initialized all the buffers.
+        """
+        # Filter the actuator DOFs that this action manager controls
+        actuator_dofs = self._actuator_manager.dofs
+        index_filter = []
+        for filter in self._actuator_filter:
+            for index, (name, dof_idx) in enumerate[tuple[str, int]](
+                actuator_dofs.items()
+            ):
+                if name == filter or re.match(f"^{filter}$", name):
+                    self._dofs[name] = dof_idx
+                    index_filter.append(index)
+        self._actuator_dof_filter = torch.tensor(
+            index_filter, device=gs.device, dtype=gs.tc_int
+        )
 
     def step(self, actions: torch.Tensor) -> None:
         """

--- a/genesis_forge/managers/action/base.py
+++ b/genesis_forge/managers/action/base.py
@@ -3,6 +3,7 @@ import torch
 import numpy as np
 from gymnasium import spaces
 import genesis as gs
+from deprecated import deprecated
 from genesis_forge.genesis_env import GenesisEnv
 from genesis_forge.managers.actuator import ActuatorManager
 from genesis_forge.managers.base import BaseManager
@@ -27,8 +28,8 @@ class BaseActionManager(BaseManager):
     Args:
         env: The environment to manage the DOF actuators for.
         actuator_manager: The actuator manager which is used to setup and control the DOF joints.
-        actuator_filter: Which joints of the actuator manager that this action manager will control.
-                   These can be full names or regular expressions.
+        actuator_joints: Which joints of the actuator manager that this action manager will control.
+                         These can be full names or regular expressions.
         delay_step: The number of steps to delay the actions for.
                     This is an easy way to emulate the latency in the system.
     """
@@ -37,7 +38,7 @@ class BaseActionManager(BaseManager):
         self,
         env: GenesisEnv,
         actuator_manager: ActuatorManager | None = None,
-        actuator_filter: list[str] | str = ".*",
+        actuator_joints: list[str] | str = ".*",
         delay_step: int = 0,
         **kwargs,
     ):
@@ -47,8 +48,8 @@ class BaseActionManager(BaseManager):
         self._delay_step = delay_step
         self._action_delay_buffer = []
         self._actuator_manager = actuator_manager
-        self._actuator_filter = (
-            [actuator_filter] if isinstance(actuator_filter, str) else actuator_filter
+        self._actuator_joints = (
+            [actuator_joints] if isinstance(actuator_joints, str) else actuator_joints
         )
         self._dofs: dict[int, str] = {}
         self._actuator_dof_filter: torch.Tensor = None
@@ -86,10 +87,15 @@ class BaseActionManager(BaseManager):
     """
 
     @property
-    def actuators(self) -> ActuatorManager:
+    def actuator_manager(self) -> ActuatorManager:
         """
         Get the actuator manager.
         """
+        return self._actuator_manager
+
+    @property
+    @deprecated(version="0.4.0", reason="Use `actuator_manager` instead")
+    def actuators(self) -> ActuatorManager:
         return self._actuator_manager
 
     @property
@@ -116,7 +122,7 @@ class BaseActionManager(BaseManager):
     @property
     def actuator_dof_filter(self) -> torch.Tensor:
         """
-        An index filer for actuator DOF values.
+        An index filter for the actuator DOF buffer values.
         """
         return self._actuator_dof_filter
 
@@ -151,6 +157,63 @@ class BaseActionManager(BaseManager):
         return self._raw_actions
 
     """
+    DOF convenience wrappers
+    """
+
+    def get_dofs_position(self):
+        """
+        A wrapper for `RigidEntity.get_dofs_limits` that returns the position limits of the controlled DOFs.
+
+        Returns:
+            position: tuple[torch.Tensor, torch.Tensor]
+                      The position of the DOFs managed by this action manager.
+        """
+        return self.actuator_manager.get_dofs_position(dofs_idx=self.dofs_idx)
+
+    def get_dofs_limits(self):
+        """
+        A wrapper for `RigidEntity.get_dofs_limit` that returns the limits of the controlled DOFs.
+
+        Returns:
+            lower_limit: torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
+                         The lower limit of the positional limits for the entity's dofs.
+            upper_limit: torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
+                         The upper limit of the positional limits for the entity's dofs.
+        """
+        return self.actuator_manager.get_dofs_limits(dofs_idx=self.dofs_idx)
+
+    def get_dofs_velocity(self, clip: tuple[float, float] = None):
+        """
+        A wrapper for `RigidEntity.get_dofs_velocity` that returns the current velocity of the controlled DOFs.
+
+        Args:
+            clip: Range to clip the velocity to.
+
+        Returns:
+            velocity: torch.Tensor, shape (n_envs, n_dofs)
+            The velocity of the enabled DOFs managed by this action manager.
+        """
+        return self.actuator_manager.get_dofs_velocity(
+            clip=clip, dofs_idx=self.dofs_idx
+        )
+
+    def get_dofs_force(self, clip_to_max_force: bool = False):
+        """
+        A wrapper for `RigidEntity.get_dofs_force` that returns the force experienced by the controlled DOFs.
+
+        Args:
+            clip_to_max_force: Clip the force returned to the maximum force defined by the `max_force` parameter
+                               defined in the actuator manager.
+
+        Returns:
+            force: torch.Tensor, shape (n_envs, n_dofs)
+            The force experienced by the enabled DOFs.
+        """
+        return self.actuator_manager.get_dofs_force(
+            clip_to_max_force=clip_to_max_force, dofs_idx=self.dofs_idx
+        )
+
+    """
     Lifecycle Operations
     """
 
@@ -161,7 +224,7 @@ class BaseActionManager(BaseManager):
         # Filter the actuator DOFs that this action manager controls
         actuator_dofs = self._actuator_manager.dofs
         index_filter = []
-        for filter in self._actuator_filter:
+        for filter in self._actuator_joints:
             for index, (name, dof_idx) in enumerate[tuple[str, int]](
                 actuator_dofs.items()
             ):

--- a/genesis_forge/managers/action/position_action_manager.py
+++ b/genesis_forge/managers/action/position_action_manager.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 import re
 import torch
 import genesis as gs
-import numpy as np
-from gymnasium import spaces
 from typing import Any, Callable, TypeVar
-from deprecated import deprecated
 from genesis_forge.genesis_env import GenesisEnv
 from genesis_forge.managers.action.base import BaseActionManager
 from genesis_forge.values import ensure_dof_pattern
@@ -28,8 +25,8 @@ class PositionActionManager(BaseActionManager):
     Args:
         env: The environment to manage the DOF actuators for.
         actuator_manager: The actuator manager which is used to setup and control the DOF joints.
-        actuator_filter: Which joints of the actuator manager that this action manager will control.
-                   These can be full names or regular expressions.
+        actuator_joints: Which joints of the actuator manager that this action manager will control.
+                         These can be full names or regular expressions.
         scale: How much to scale the action.
         offset: Offset factor for the action.
         use_default_offset: Whether to use default joint positions configured in the articulation asset as offset. Defaults to True.
@@ -59,6 +56,7 @@ class PositionActionManager(BaseActionManager):
                     scale=0.5,
                     use_default_offset=True,
                     actuator_manager=self.actuator_manager,
+                    actuator_joints=[".*"], # optional joint filter
                 )
 
     Example using the manager directly::
@@ -108,7 +106,7 @@ class PositionActionManager(BaseActionManager):
         self,
         env: GenesisEnv,
         actuator_manager: ActuatorManager | None = None,
-        actuator_filter: list[str] | str = ".*",
+        actuator_joints: list[str] | str = ".*",
         scale: float | dict[str, float] = 1.0,
         offset: float | dict[str, float] = 0.0,
         clip: tuple[float, float] | dict[str, tuple[float, float]] = None,
@@ -122,7 +120,7 @@ class PositionActionManager(BaseActionManager):
             env,
             delay_step=delay_step,
             actuator_manager=actuator_manager,
-            actuator_filter=actuator_filter,
+            actuator_joints=actuator_joints,
             **kwargs,
         )
         self._offset_cfg = ensure_dof_pattern(offset)
@@ -146,64 +144,7 @@ class PositionActionManager(BaseActionManager):
         """
         Return the default DOF positions.
         """
-        return self.actuators.default_dofs_pos[:, self.actuator_dof_filter]
-
-    """
-    DOF Getters
-    """
-
-    @deprecated(
-        version="0.3,0",
-        reason="Use the actuator manager directly.",
-    )
-    def get_dofs_position(self, noise: float = 0.0):
-        """
-        Deprecated: Use the actuator manager directly.
-
-        Return the current position of the enabled DOFs.
-        This is a wrapper for `RigidEntity.get_dofs_position`.
-
-        Args:
-            noise: The maximum amount of random noise to add to the position values returned.
-        """
-        return self.actuators.get_dofs_position(noise, self.dofs_idx)
-
-    @deprecated(
-        version="0.3,0",
-        reason="Use the actuator manager directly.",
-    )
-    def get_dofs_velocity(self, noise: float = 0.0, clip: tuple[float, float] = None):
-        """
-        Deprecated: Use the actuator manager directly.
-
-        Return the current velocity of the enabled DOFs.
-        This is a wrapper for `RigidEntity.get_dofs_velocity`.
-
-        Args:
-            noise: The maximum amount of random noise to add to the velocity values returned.
-            clip: Clip the velocity returned.
-        """
-        return self.actuators.get_dofs_velocity(noise, clip, self.dofs_idx)
-
-    @deprecated(
-        version="0.3,0",
-        reason="Use the actuator manager directly.",
-    )
-    def get_dofs_force(self, noise: float = 0.0, clip_to_max_force: bool = False):
-        """
-        Deprecated: Use the actuator manager directly.
-
-        Return the force experienced by the enabled DOFs.
-        This is a wrapper for `RigidEntity.get_dofs_force`.
-
-        Args:
-            noise: The maximum amount of random noise to add to the force values returned.
-            clip_to_max_force: Clip the force returned to the maximum force defined by the `max_force` parameter.
-
-        Returns:
-            The force experienced by the enabled DOFs.
-        """
-        return self.actuators.get_dofs_force(noise, clip_to_max_force, self.dofs_idx)
+        return self.actuator_manager.default_dofs_pos[:, self.actuator_dof_filter]
 
     """
     Lifecycle Operations
@@ -216,7 +157,7 @@ class PositionActionManager(BaseActionManager):
         super().build()
 
         # Define the clip values
-        lower_limit, upper_limit = self.actuators.get_dofs_limits(self.dofs_idx)
+        lower_limit, upper_limit = self.actuator_manager.get_dofs_limits(self.dofs_idx)
         self._clip_values = torch.stack([lower_limit, upper_limit], dim=1)
         if self._clip_cfg is not None:
             self._get_dof_value_tensor(self._clip_cfg, output=self._clip_values)
@@ -229,9 +170,7 @@ class PositionActionManager(BaseActionManager):
         # Offset
         self._offset_values = None
         if self._use_default_offset:
-            self._offset_values = self.actuators.default_dofs_pos[
-                :, self.actuator_dof_filter
-            ]
+            self._offset_values = self.default_dofs_pos
         else:
             offset = self._offset_cfg if self._offset_cfg is not None else 0.0
             self._offset_values = self._get_dof_value_tensor(offset)
@@ -277,7 +216,7 @@ class PositionActionManager(BaseActionManager):
         )
 
         # Set target positions
-        self.actuators.control_dofs_position(actions, self.dofs_idx)
+        self.actuator_manager.control_dofs_position(actions, self.dofs_idx)
 
         return actions
 

--- a/genesis_forge/managers/action/position_within_limits.py
+++ b/genesis_forge/managers/action/position_within_limits.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+import re
 import torch
+from genesis import gs
 
 from genesis_forge.genesis_env import GenesisEnv
+from genesis_forge.values import ensure_dof_pattern
 from .position_action_manager import PositionActionManager
 from genesis_forge.managers.actuator import ActuatorManager
 
@@ -13,13 +16,15 @@ class PositionWithinLimitsActionManager(PositionActionManager):
     Args:
         env: The environment to manage the DOF actuators for.
         actuator_manager: The actuator manager which is used to setup and control the DOF joints.
-        actuator_filter: Which joints of the actuator manager that this action manager will control.
-                   These can be full names or regular expressions.
+        actuator_joints: Which joints of the actuator manager that this action manager will control.
+                         These can be full names or regular expressions.
+        limit: (optional) A dictionary of DOF name patterns and their position limits.
+               If omitted, the limits will be set to the limits of the actuators defined in the model.
         quiet_action_errors: Whether to quiet action errors.
         delay_step: The number of steps to delay the actions for.
                     This is an easy way to emulate the latency in the system.
 
-    Example::
+    Simple example using the limits defined in the model::
 
         class MyEnv(ManagedEnvironment):
             def __init__(self, *args, **kwargs):
@@ -29,22 +34,37 @@ class PositionWithinLimitsActionManager(PositionActionManager):
                 self.actuator_manager = ActuatorManager(
                     self,
                     joint_names=".*",
-                    default_pos={
-                        # Hip joints
-                        "Leg[1-2]_Hip": -1.0,
-                        "Leg[3-4]_Hip": 1.0,
-                        # Femur joints
-                        "Leg[1-4]_Femur": 0.5,
-                        # Tibia joints
-                        "Leg[1-4]_Tibia": 0.6,
-                    },
+                    default_pos={".*": 0.0},
                     kp={".*": 50},
                     kv={".*": 0.5},
-                    max_force={".*": 8.0},
                 )
                 self.action_manager = PositionalActionManager(
                     self,
                     actuator_manager=self.actuator_manager,
+                    actuator_joints=[".*"], # optional joint filter
+                )
+
+        Example defining custom limits::
+
+            class MyEnv(ManagedEnvironment):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def config(self):
+                self.actuator_manager = ActuatorManager(
+                    self,
+                    joint_names=".*",
+                    default_pos={".*": 0.0},
+                    kp={".*": 50},
+                    kv={".*": 0.5},
+                )
+                self.action_manager = PositionalActionManager(
+                    self,
+                    actuator_manager=self.actuator_manager,
+                    limit = {
+                        ".*_Hip": (-1.0, 1.0),
+                        ".*_Femur": (-1.5, 1.2),
+                    },
                 )
 
     """
@@ -53,19 +73,21 @@ class PositionWithinLimitsActionManager(PositionActionManager):
         self,
         env: GenesisEnv,
         actuator_manager: ActuatorManager | None = None,
-        actuator_filter: list[str] | str = ".*",
+        actuator_joints: list[str] | str = ".*",
         quiet_action_errors: bool = False,
+        limit: tuple[float, float] | dict[str, tuple[float, float]] = {},
         delay_step: int = 0,
         **kwargs,
     ):
         super().__init__(
             env,
             actuator_manager=actuator_manager,
-            actuator_filter=actuator_filter,
+            actuator_joints=actuator_joints,
             quiet_action_errors=quiet_action_errors,
             delay_step=delay_step,
             **kwargs,
         )
+        self._limit_cfg = ensure_dof_pattern(limit)
 
     """
     Lifecycle Operations
@@ -77,7 +99,7 @@ class PositionWithinLimitsActionManager(PositionActionManager):
         """
         super().build()
 
-        lower, upper = self.actuators.get_dofs_limits(self.dofs_idx)
+        lower, upper = self._get_dof_limits()
         lower = lower.unsqueeze(0).expand(self.env.num_envs, -1)
         upper = upper.unsqueeze(0).expand(self.env.num_envs, -1)
         self._offset = (upper + lower) * 0.5
@@ -99,6 +121,29 @@ class PositionWithinLimitsActionManager(PositionActionManager):
         actions = actions * self._scale + self._offset
 
         # Set target positions
-        self._actuator_manager.control_dofs_position(actions, self.dofs_idx)
+        self.actuator_manager.control_dofs_position(actions, self.dofs_idx)
 
         return actions
+
+    """
+    Internal methods
+    """
+
+    def _get_dof_limits(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Define the position limits for the DOFs
+        """
+        lower, upper = self.get_dofs_limits()
+        is_set = [False] * self.num_actions
+        dof_names = list[str](self.dofs.keys())
+        for pattern, value in self._limit_cfg.items():
+            found = False
+            for i, name in enumerate[str](dof_names):
+                if not is_set[i] and re.match(f"^{pattern}$", name):
+                    is_set[i] = True
+                    lower[i] = value[0]
+                    upper[i] = value[1]
+                    found = True
+            if not found:
+                raise RuntimeError(f"Joint DOF '{pattern}' not found.")
+        return lower, upper

--- a/genesis_forge/managers/action/position_within_limits.py
+++ b/genesis_forge/managers/action/position_within_limits.py
@@ -44,9 +44,9 @@ class PositionWithinLimitsActionManager(PositionActionManager):
                     actuator_joints=[".*"], # optional joint filter
                 )
 
-        Example defining custom limits::
+    Example defining custom limits::
 
-            class MyEnv(ManagedEnvironment):
+        class MyEnv(ManagedEnvironment):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -201,7 +201,8 @@ class ActuatorManager(BaseManager):
             position: torch.Tensor, shape (n_envs, n_dofs)
             The position of the enabled DOFs.
         """
-        pos = self._robot.get_dofs_position(dofs_idx or self.dofs_idx)
+        dofs_idx = dofs_idx if dofs_idx is not None else self.dofs_idx
+        pos = self._robot.get_dofs_position(dofs_idx)
         if noise > 0.0:
             pos = self._add_random_noise(pos, noise)
         return pos
@@ -225,7 +226,8 @@ class ActuatorManager(BaseManager):
             velocity:torch.Tensor, shape (n_envs, n_dofs)
             The velocity of the enabled DOFs.
         """
-        vel = self._robot.get_dofs_velocity(dofs_idx or self.dofs_idx)
+        dofs_idx = dofs_idx if dofs_idx is not None else self.dofs_idx
+        vel = self._robot.get_dofs_velocity(dofs_idx)
         if noise > 0.0:
             vel = self._add_random_noise(vel, noise)
         if clip is not None:
@@ -251,7 +253,8 @@ class ActuatorManager(BaseManager):
             force: torch.Tensor, shape (n_envs, n_dofs)
             The force experienced by the enabled DOFs.
         """
-        force = self._robot.get_dofs_force(dofs_idx or self.dofs_idx)
+        dofs_idx = dofs_idx if dofs_idx is not None else self.dofs_idx
+        force = self._robot.get_dofs_force(dofs_idx)
         if noise > 0.0:
             force = self._add_random_noise(force, noise)
         if clip_to_max_force:
@@ -275,7 +278,8 @@ class ActuatorManager(BaseManager):
             upper_limit: torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
                          The upper limit of the positional limits for the entity's dofs.
         """
-        return self._robot.get_dofs_limit(dofs_idx or self.dofs_idx)
+        dofs_idx = dofs_idx if dofs_idx is not None else self.dofs_idx
+        return self._robot.get_dofs_limit(dofs_idx)
 
     def set_dofs_position(
         self, position: torch.Tensor, dofs_idx: list[int] | None = None

--- a/genesis_forge/managers/actuator/actuator_manager.py
+++ b/genesis_forge/managers/actuator/actuator_manager.py
@@ -186,7 +186,9 @@ class ActuatorManager(BaseManager):
     Actuator handlers
     """
 
-    def get_dofs_position(self, noise: float = 0.0, dofs_idx: list[int] | None = None):
+    def get_dofs_position(
+        self, noise: float = 0.0, dofs_idx: list[int] | None = None
+    ) -> torch.Tensor:
         """
         Return the current position of the configured DOFs.
         This is a wrapper for `RigidEntity.get_dofs_position`.
@@ -196,6 +198,7 @@ class ActuatorManager(BaseManager):
             dofs_idx: The indices of the DOFs to get the position for. If None, all the DOFs of this actuator manager are used.
 
         Returns:
+            position: torch.Tensor, shape (n_envs, n_dofs)
             The position of the enabled DOFs.
         """
         pos = self._robot.get_dofs_position(dofs_idx or self.dofs_idx)
@@ -208,7 +211,7 @@ class ActuatorManager(BaseManager):
         noise: float = 0.0,
         clip: tuple[float, float] = None,
         dofs_idx: list[int] | None = None,
-    ):
+    ) -> torch.Tensor:
         """
         Return the current velocity of the configured DOFs.
         This is a wrapper for `RigidEntity.get_dofs_velocity`.
@@ -219,6 +222,7 @@ class ActuatorManager(BaseManager):
             dofs_idx: The indices of the DOFs to get the velocity for. If None, all the DOFs of this actuator manager are used.
 
         Returns:
+            velocity:torch.Tensor, shape (n_envs, n_dofs)
             The velocity of the enabled DOFs.
         """
         vel = self._robot.get_dofs_velocity(dofs_idx or self.dofs_idx)
@@ -233,7 +237,7 @@ class ActuatorManager(BaseManager):
         noise: float = 0.0,
         clip_to_max_force: bool = False,
         dofs_idx: list[int] | None = None,
-    ):
+    ) -> torch.Tensor:
         """
         Return the force experienced by the configured DOFs.
         This is a wrapper for `RigidEntity.get_dofs_force`.
@@ -244,6 +248,7 @@ class ActuatorManager(BaseManager):
             dofs_idx: The indices of the DOFs to get the force for. If None, all the DOFs of this actuator manager are used.
 
         Returns:
+            force: torch.Tensor, shape (n_envs, n_dofs)
             The force experienced by the enabled DOFs.
         """
         force = self._robot.get_dofs_force(dofs_idx or self.dofs_idx)
@@ -258,15 +263,17 @@ class ActuatorManager(BaseManager):
         self, dofs_idx: list[int] | None = None
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
-        Return the limits of the configured DOFs.
+        Return the position limits of the configured DOFs.
         This is a wrapper for `RigidEntity.get_dofs_limit`.
 
         Args:
             dofs_idx: The indices of the DOFs to get the limits for. If None, all the DOFs of this actuator manager are used.
 
         Returns:
-            A tuple of two tensors, the first is the lower limits and the second is the upper limits.
-            Each tensor is of shape (num_envs, num_dofs).
+            lower_limit: torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
+                         The lower limit of the positional limits for the entity's dofs.
+            upper_limit: torch.Tensor, shape (n_dofs,) or (n_envs, n_dofs)
+                         The upper limit of the positional limits for the entity's dofs.
         """
         return self._robot.get_dofs_limit(dofs_idx or self.dofs_idx)
 
@@ -425,7 +432,7 @@ class ActuatorManager(BaseManager):
 
     def _should_set_value(self, value_name: ValueName) -> bool:
         """
-        Check if the actuator control value should.
+        Check if the actuator value should be set.
         We don't want to set the value if we've already set it and there is no noise associated with it.
         """
         cfg = self._values[value_name]
@@ -436,7 +443,9 @@ class ActuatorManager(BaseManager):
         return True
 
     def _fill_value_buffer(
-        self, value_name: ValueName, config: NoisyValue[float] | None
+        self,
+        value_name: ValueName,
+        config: dict | None,
     ):
         """
         Given a ActuatorValue dict, loop over the entries, and set them to the appropriate value buffer DOF indices that match

--- a/genesis_forge/mdp/rewards.py
+++ b/genesis_forge/mdp/rewards.py
@@ -103,7 +103,7 @@ def dof_similar_to_default(
     Args:
         env: The Genesis environment containing the robot
         actuator_manager: The actuator manager for the robot/entity.
-        action_manager: (deprecated) The DOF action manager
+        action_manager: The DOF action manager
 
     Returns:
         torch.Tensor: Penalty for joint poses far away from default pose


### PR DESCRIPTION
Refactored the action/actuator managers so that multiple action managers can be used for a single robot. This could be useful if some joints are driven by position-based actuators and others by torque (not implemented yet)

You can see an example of this in examples/multiple_action_managers.

# How it works

```python
self.actuator_manager = ActuatorManager(
    self,
    joint_names=[
        "FL_.*_joint",
        "FR_.*_joint",
        "RL_.*_joint",
        "RR_.*_joint",
    ],
    default_pos={
        ".*_hip_joint": 0.0,
        "FL_thigh_joint": 0.8,
        "FR_thigh_joint": 0.8,
        "RL_thigh_joint": 1.0,
        "RR_thigh_joint": 1.0,
        ".*_calf_joint": -1.5,
    },
    kp=20,
    kv=0.5,
)

self.hip_action_manager = PositionWithinLimitsActionManager(
    self,
    actuator_manager=self.actuator_manager,
    actuator_filter=[".*_hip_joint"],
)

self.leg_action_manager = PositionActionManager(
    self,
    actuator_manager=self.actuator_manager,
    actuator_filter=[
        ".*_thigh_joint",
        ".*_calf_joint",
    ],
    scale=0.25,
    clip=(-100.0, 100.0),
    use_default_offset=True,
)
```

In this case, there's one actuator manager, and each action manager defines `actuator_filter` arg to select which actuators it's managing. The hip actuators are controlled by `PositionWithinLimitsActionManager,` and the other actuators are controlled by `PositionActionManager`.  In theory, there could also be multiple actuator managers, as well.

_FYI: I'm not sure if I like the name of the argument `actuator_filter`. This might change._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces multi-action-manager support with actuator-level filtering and updates core plumbing to compose/split action spaces accordingly.
> 
> - **Core (`ManagedEnvironment`)**: `actuator`/`action` managers become lists; build/reset/step iterate managers; new `_build_action_managers` concatenates per-manager `action_space` and records index ranges to route action slices.
> - **New/Refactored action API**: `BaseActionManager` adds `actuator_joints` filtering, DOF mapping/helpers, action delay buffer, and deprecates inline actuator args. `PositionActionManager` and `PositionWithinLimitsActionManager` now inherit from it, support joint filtering, and use per-manager DOF indices; limits can be overridden per joint pattern.
> - **ActuatorManager**: exposes `dofs` map; getters/setters/control methods accept optional `dofs_idx` to operate on subsets; doc cleanups.
> - **Rewards**: `dof_similar_to_default` docs updated to accept either `actuator_manager` or `action_manager`.
> - **Examples**: Adds `examples/multiple_action_managers` (Go2 env, README, train/eval) demonstrating hips vs legs controlled by different action managers; minor wording tweak in simple example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a99c4c75a4657219542a280c6509e7f1aa665cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->